### PR TITLE
feat: support Python 3.7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.x", "3.10-dev"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.x", "3.10-dev"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test-prs.yaml
+++ b/.github/workflows/test-prs.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.x", "3.10-dev"]
+        python-version: ["3.7", "3.8", "3.x", "3.10-dev"]
     defaults:
       run:
         shell: bash

--- a/di/__init__.py
+++ b/di/__init__.py
@@ -1,6 +1,13 @@
-import importlib.metadata as _importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    # python <3.8
+    import importlib_metadata  # type: ignore
 
-__version__ = _importlib_metadata.version(__name__)
+try:
+    __version__ = importlib_metadata.version(__name__)  # type: ignore # for py 3.7
+except importlib_metadata.PackageNotFoundError:  # type: ignore # for py 3.7
+    __version__ = "0.0.0"
 
 
 from di.container import Container

--- a/di/_inspect.py
+++ b/di/_inspect.py
@@ -82,6 +82,7 @@ def get_annotations(call: DependencyProvider) -> Dict[str, Any]:
         # callable class
         types_from = call.__call__  # type: ignore
     else:
+        # method
         types_from = call
     return get_type_hints(types_from)
 

--- a/di/dependant.py
+++ b/di/dependant.py
@@ -93,7 +93,7 @@ class Dependant(DependantProtocol[DependencyType], object):
 
     @join_docstring_from(DependantProtocol[Any].__hash__)
     def __hash__(self) -> int:
-        return hash(self.call)
+        return id(self.call)
 
     @join_docstring_from(DependantProtocol[Any].__eq__)
     def __eq__(self, o: object) -> bool:

--- a/di/types/dependencies.py
+++ b/di/types/dependencies.py
@@ -4,7 +4,7 @@ import inspect
 import sys
 from typing import Any, Dict, Optional
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Protocol, runtime_checkable
 else:
     from typing import Protocol, runtime_checkable

--- a/di/types/dependencies.py
+++ b/di/types/dependencies.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Dict, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, Optional
+
+try:
+    from typing import Protocol, runtime_checkable
+except ImportError:
+    from typing_extensions import Protocol, runtime_checkable  # type: ignore
 
 from di._inspect import DependencyParameter
 from di.types.providers import (

--- a/di/types/dependencies.py
+++ b/di/types/dependencies.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from typing import Any, Dict, Optional
 
-try:
+if sys.version_info < (3, 7):
+    from typing_extensions import Protocol, runtime_checkable
+else:
     from typing import Protocol, runtime_checkable
-except ImportError:
-    from typing_extensions import Protocol, runtime_checkable  # type: ignore
 
 from di._inspect import DependencyParameter
 from di.types.providers import (

--- a/di/types/executor.py
+++ b/di/types/executor.py
@@ -1,9 +1,10 @@
+import sys
 from typing import Awaitable, Callable, List, TypeVar, Union
 
-try:
+if sys.version_info < (3, 7):
+    from typing_extensions import Protocol
+else:
     from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore
 
 ResultType = TypeVar("ResultType")
 

--- a/di/types/executor.py
+++ b/di/types/executor.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Awaitable, Callable, List, TypeVar, Union
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:
     from typing import Protocol

--- a/di/types/executor.py
+++ b/di/types/executor.py
@@ -1,23 +1,28 @@
-import typing
+from typing import Awaitable, Callable, List, TypeVar, Union
 
-ResultType = typing.TypeVar("ResultType")
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore
 
-Task = typing.Callable[[], typing.Union[None, typing.Awaitable[None]]]
+ResultType = TypeVar("ResultType")
+
+Task = Callable[[], Union[None, Awaitable[None]]]
 
 
-class SyncExecutor(typing.Protocol):
+class SyncExecutor(Protocol):
     def execute_sync(
         self,
-        tasks: typing.List[typing.List[Task]],
-        get_result: typing.Callable[[], ResultType],
+        tasks: List[List[Task]],
+        get_result: Callable[[], ResultType],
     ) -> ResultType:
         raise NotImplementedError
 
 
-class AsyncExecutor(typing.Protocol):
+class AsyncExecutor(Protocol):
     async def execute_async(
         self,
-        tasks: typing.List[typing.List[Task]],
-        get_result: typing.Callable[[], ResultType],
+        tasks: List[List[Task]],
+        get_result: Callable[[], ResultType],
     ) -> ResultType:
         raise NotImplementedError

--- a/di/types/solved.py
+++ b/di/types/solved.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import functools
 from typing import Any, Dict, Generic, List, Union
 
 from di._inspect import DependencyParameter
@@ -26,8 +25,7 @@ class SolvedDependency(Generic[DependencyType]):
     ]
     _tasks: List[List[Union[AsyncTask[Dependency], SyncTask[Dependency]]]]
 
-    @functools.cached_property
-    def flat_subdependants(self) -> List[DependantProtocol[Any]]:
+    def get_flat_subdependants(self) -> List[DependantProtocol[Any]]:
         """Get an exhaustive list of all of the dependencies of this dependency,
         in no particular order.
         """

--- a/docs/src/bind_as_a_dep.py
+++ b/docs/src/bind_as_a_dep.py
@@ -1,5 +1,10 @@
 from dataclasses import dataclass
-from typing import List, Protocol
+from typing import List
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore
 
 from di import Container, Dependant
 

--- a/docs/src/bind_as_a_dep.py
+++ b/docs/src/bind_as_a_dep.py
@@ -2,7 +2,7 @@ import sys
 from dataclasses import dataclass
 from typing import List
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:
     from typing import Protocol

--- a/docs/src/bind_as_a_dep.py
+++ b/docs/src/bind_as_a_dep.py
@@ -1,10 +1,11 @@
+import sys
 from dataclasses import dataclass
 from typing import List
 
-try:
+if sys.version_info < (3, 7):
+    from typing_extensions import Protocol
+else:
     from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore
 
 from di import Container, Dependant
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -9,6 +9,7 @@ python-versions = ">=3.6.2"
 [package.dependencies]
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
@@ -53,6 +54,9 @@ category = "dev"
 optional = false
 python-versions = ">=2.7"
 
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
@@ -72,6 +76,7 @@ pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
 regex = ">=2020.1.8"
 tomli = ">=0.2.6,<2.0.0"
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
 typing-extensions = [
     {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
     {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
@@ -132,6 +137,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -192,6 +198,7 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
@@ -276,11 +283,12 @@ python-versions = ">=3.5"
 name = "importlib-metadata"
 version = "4.8.1"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -332,6 +340,9 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
 [package.extras]
 testing = ["coverage", "pyyaml"]
 
@@ -361,7 +372,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "mike"
-version = "1.1.1"
+version = "1.1.2"
 description = "Manage multiple versions of your MkDocs-powered documentation"
 category = "dev"
 optional = false
@@ -442,6 +453,7 @@ python-versions = ">=3.5"
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
 toml = "*"
+typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.7.4"
 
 [package.extras]
@@ -514,6 +526,9 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
@@ -529,6 +544,7 @@ python-versions = ">=3.6.1"
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
@@ -605,6 +621,7 @@ python-versions = ">=3.6"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -725,6 +742,7 @@ python-versions = ">=3.6,<4.0"
 colorama = ">=0.4.0,<0.5.0"
 commonmark = ">=0.9.0,<0.10.0"
 pygments = ">=2.6.0,<3.0.0"
+typing-extensions = {version = ">=3.7.4,<4.0.0", markers = "python_version < \"3.8\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
@@ -763,6 +781,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 anyio = ">=3.0.0,<4"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "graphene"]
@@ -785,6 +804,7 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 rich = ">=10.7.0,<11.0.0"
+typing-extensions = {version = ">=3.10.0,<4.0.0", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "toml"
@@ -820,10 +840,18 @@ sniffio = "*"
 sortedcontainers = "*"
 
 [[package]]
+name = "typed-ast"
+version = "1.4.3"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -863,6 +891,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 "backports.entry-points-selectable" = ">=1.0.4"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
@@ -885,7 +914,7 @@ watchmedo = ["PyYAML (>=3.10)"]
 name = "zipp"
 version = "3.6.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -895,8 +924,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.8.0,<4"
-content-hash = "096f9e04a949576e8e1cd08c9068194bbfe7813985a4fc003363e4e30301dd28"
+python-versions = ">=3.7.0,<4"
+content-hash = "809b598ee50ea87aed30f92b7b98857d107bc6834548e8a59cbd7dee4d888280"
 
 [metadata.files]
 anyio = [
@@ -1152,8 +1181,8 @@ mergedeep = [
     {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
 ]
 mike = [
-    {file = "mike-1.1.1-py3-none-any.whl", hash = "sha256:30d221ac6fca3d5820b333103d4086437cf4d16b122c188b3740c3852f3e4e1d"},
-    {file = "mike-1.1.1.tar.gz", hash = "sha256:93e0a3a904311ebb432d3210242cca38286fb1ff1944e08bb1e7b46c149ebce1"},
+    {file = "mike-1.1.2-py3-none-any.whl", hash = "sha256:4c307c28769834d78df10f834f57f810f04ca27d248f80a75f49c6fa2d1527ca"},
+    {file = "mike-1.1.2.tar.gz", hash = "sha256:56c3f1794c2d0b5fdccfa9b9487beb013ca813de2e3ad0744724e9d34d40b77b"},
 ]
 mkautodoc = [
     {file = "mkautodoc-0.1.0.tar.gz", hash = "sha256:7c2595f40276b356e576ce7e343338f8b4fa1e02ea904edf33fadf82b68ca67c"},
@@ -1394,6 +1423,38 @@ tomli = [
 trio = [
     {file = "trio-0.19.0-py3-none-any.whl", hash = "sha256:c27c231e66336183c484fbfe080fa6cc954149366c15dc21db8b7290081ec7b8"},
     {file = "trio-0.19.0.tar.gz", hash = "sha256:895e318e5ec5e8cea9f60b473b6edb95b215e82d99556a03eb2d20c5e027efe1"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,10 @@ classifiers=[
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8.0,<4"
+python = ">=3.7.0,<4"
 anyio = "~3"
+importlib-metadata = {version = ">=3", python = "<3.8"}
+typing-extensions = {version = ">=3", python = "<3.8"}
 
 [tool.poetry.group.lint.dependencies]
 black = ">=21.9b0,<22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.4.23"
+version = "0.5.0"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/docs/test_gather_deps_example.py
+++ b/tests/docs/test_gather_deps_example.py
@@ -1,8 +1,11 @@
+import sys
+
 import pytest
 
 from docs.src import gather_deps_example
 
 
 @pytest.mark.anyio
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="Can't runtime check protocol")
 async def test_web_framework_example() -> None:
     await gather_deps_example.web_framework()

--- a/tests/docs/test_gather_deps_example.py
+++ b/tests/docs/test_gather_deps_example.py
@@ -6,6 +6,6 @@ from docs.src import gather_deps_example
 
 
 @pytest.mark.anyio
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="Can't runtime check protocol")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Can't runtime check protocol")
 async def test_web_framework_example() -> None:
     await gather_deps_example.web_framework()

--- a/tests/docs/test_sharing_example.py
+++ b/tests/docs/test_sharing_example.py
@@ -1,5 +1,12 @@
+import sys
+
+import pytest
+
 from docs.src import sharing
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="Missing type annotations in stdlib"
+)
 def test_web_framework_example() -> None:
     sharing.main()

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -6,7 +6,7 @@ import time
 from contextlib import contextmanager
 from typing import Any, AsyncGenerator, Generator, List
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Literal
 else:
     from typing import Literal

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,14 +1,15 @@
 import contextvars
 import functools
+import sys
 import threading
 import time
 from contextlib import contextmanager
 from typing import Any, AsyncGenerator, Generator, List
 
-try:
-    from typing import Literal  # type: ignore
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+if sys.version_info < (3, 7):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
 import anyio
 import pytest

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -3,7 +3,12 @@ import functools
 import threading
 import time
 from contextlib import contextmanager
-from typing import Any, AsyncGenerator, Generator, List, Literal
+from typing import Any, AsyncGenerator, Generator, List
+
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal
 
 import anyio
 import pytest

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -8,7 +8,7 @@ from typing import Any, AsyncGenerator, Generator, List
 try:
     from typing import Literal  # type: ignore
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 
 import anyio
 import pytest

--- a/tests/test_get_flat_dependencies.py
+++ b/tests/test_get_flat_dependencies.py
@@ -47,28 +47,28 @@ async def test_get_flat_dependencies():
 
     async with container.enter_global_scope("dummy"):
         assert_compare_call(
-            container.solve(Dependant(call=call7)).flat_subdependants,
+            container.solve(Dependant(call=call7)).get_flat_subdependants(),
             [call1, call2, call3, call4, call6],
         )
         assert_compare_call(
-            container.solve(Dependant(call=call6)).flat_subdependants,
+            container.solve(Dependant(call=call6)).get_flat_subdependants(),
             [call1, call2, call3, call4],
         )
         assert_compare_call(
-            container.solve(Dependant(call=call5)).flat_subdependants,
+            container.solve(Dependant(call=call5)).get_flat_subdependants(),
             [call1, call2, call3, call4],
         )
         assert_compare_call(
-            container.solve(Dependant(call=call4)).flat_subdependants,
+            container.solve(Dependant(call=call4)).get_flat_subdependants(),
             [call1, call2, call3],
         )
         assert_compare_call(
-            container.solve(Dependant(call=call3)).flat_subdependants, []
+            container.solve(Dependant(call=call3)).get_flat_subdependants(), []
         )
         assert_compare_call(
-            container.solve(Dependant(call=call2)).flat_subdependants,
+            container.solve(Dependant(call=call2)).get_flat_subdependants(),
             [call1],
         )
         assert_compare_call(
-            container.solve(Dependant(call=call1)).flat_subdependants, []
+            container.solve(Dependant(call=call1)).get_flat_subdependants(), []
         )

--- a/tests/test_positional_only.py
+++ b/tests/test_positional_only.py
@@ -17,7 +17,7 @@ def test_positional_only_parameters():
     return_two_def = (
         r"def return_two(one: int = Depends(return_one), /) -> int:  return one + 1"
     )
-    exec(return_two_def, globals(), locals())
+    exec(return_two_def, globals())
 
     container = Container()
     res = container.execute_sync(container.solve(Dependant(return_two)))  # type: ignore # noqa

--- a/tests/test_positional_only.py
+++ b/tests/test_positional_only.py
@@ -1,18 +1,24 @@
+import sys
+
 import pytest
 
-from di import Container, Dependant, Depends
+from di import Container, Dependant, Depends  # noqa
 
 
 def return_one() -> int:
     return 1
 
 
-def return_two(one: int = Depends(return_one), /) -> int:
-    return one + 1
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="3.7 does not support positional only args"
+)
+def test_positional_only_parameters():
+    # avoid a syntax error in 3.7, which does not support /
+    return_two_def = (
+        r"def return_two(one: int = Depends(return_one), /) -> int:  return one + 1"
+    )
+    exec(return_two_def, globals(), locals())
 
-
-@pytest.mark.anyio
-async def test_positional_only_parameters():
     container = Container()
-    res = container.execute_sync(container.solve(Dependant(return_two)))
+    res = container.execute_sync(container.solve(Dependant(return_two)))  # type: ignore # noqa
     assert res == 2

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Callable, Dict
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Literal
 else:
     from typing import Literal

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -1,9 +1,10 @@
+import sys
 from typing import Callable, Dict
 
-try:
-    from typing import Literal  # type: ignore
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+if sys.version_info < (3, 7):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
 import pytest
 

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -1,4 +1,9 @@
-from typing import Callable, Dict, Literal
+from typing import Callable, Dict
+
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal
 
 import pytest
 

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict
 try:
     from typing import Literal  # type: ignore
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 
 import pytest
 

--- a/tests/test_wiring_forward_refs.py
+++ b/tests/test_wiring_forward_refs.py
@@ -1,0 +1,16 @@
+from di import Container, Dependant
+
+
+class Foo:
+    called: bool = False
+
+    def foo(self: "Foo") -> "Foo":
+        self.called = True
+        return self
+
+
+def test_forward_ref_evalutation():
+    container = Container()
+    res = container.execute_sync(container.solve(Dependant(Foo.foo)))
+    assert isinstance(res, Foo)
+    assert res.called


### PR DESCRIPTION
3.7 works w/ `typing_extensions`.

3.6 would be a PITA: we're missing contextlib pieces and contextvars altogether. Plus it's EOL in 2 months.