### PR TITLE
perf: misc internal performance improvements

### DIFF
--- a/benchmarks/solve.py
+++ b/benchmarks/solve.py
@@ -18,7 +18,7 @@ from di.executors import ConcurrentAsyncExecutor, SimpleSyncExecutor
 async def async_concurrent():
     container = Container(executor=ConcurrentAsyncExecutor())
     solved = container.solve(
-        Dependant(generate_dag(Depends, 4, 3, 3, sync=True, sleep=(0, 0)))
+        Dependant(generate_dag(Depends, 4, 3, 3, sync=True, sleep=(0, 1e-3)))
     )
     profiler = cProfile.Profile()
     profiler.enable()
@@ -80,5 +80,5 @@ def sync_sequential_small():
 
 if __name__ == "__main__":
     anyio.run(async_concurrent)
-    # sync_sequential_large()
-    # sync_sequential_small()
+    sync_sequential_large()
+    sync_sequential_small()

--- a/benchmarks/solve.py
+++ b/benchmarks/solve.py
@@ -18,7 +18,7 @@ from di.executors import ConcurrentAsyncExecutor, SimpleSyncExecutor
 async def async_concurrent():
     container = Container(executor=ConcurrentAsyncExecutor())
     solved = container.solve(
-        Dependant(generate_dag(Depends, 4, 3, 3, sync=True, sleep=(0, 1e-3)))
+        Dependant(generate_dag(Depends, 4, 3, 3, sync=True, sleep=(0, 0)))
     )
     profiler = cProfile.Profile()
     profiler.enable()
@@ -80,5 +80,5 @@ def sync_sequential_small():
 
 if __name__ == "__main__":
     anyio.run(async_concurrent)
-    sync_sequential_large()
-    sync_sequential_small()
+    # sync_sequential_large()
+    # sync_sequential_small()

--- a/di/__init__.py
+++ b/di/__init__.py
@@ -23,7 +23,6 @@ from di.dependant import (  # noqa: E402
 )
 from di.executors import (  # noqa: E402
     ConcurrentAsyncExecutor,
-    ConcurrentSyncExecutor,
     DefaultExecutor,
     SimpleAsyncExecutor,
     SimpleSyncExecutor,
@@ -38,7 +37,6 @@ __all__ = (
     "Depends",
     "DefaultExecutor",
     "ConcurrentAsyncExecutor",
-    "ConcurrentSyncExecutor",
     "SimpleAsyncExecutor",
     "SimpleSyncExecutor",
 )

--- a/di/_utils/dag.py
+++ b/di/_utils/dag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import deque
 from typing import Deque, Dict, Iterable, List, Mapping, MutableMapping, TypeVar
 

--- a/di/_utils/execution_planning.py
+++ b/di/_utils/execution_planning.py
@@ -52,8 +52,7 @@ class ExecutionPlan(NamedTuple):
 class SolvedDependantCache(NamedTuple):
     """Private data that the Container attaches to SolvedDependant"""
 
-    tasks: Mapping[DependantBase[Any], Task[Any]]
-    dependency_dag: Mapping[DependantBase[Any], Set[DependantBase[Any]]]
+    root_task: Task[Any]
     task_dependency_dag: Mapping[Task[Any], Set[Task[Any]]]
     task_dependant_dag: Mapping[Task[Any], Set[Task[Any]]]
     execution_plan: Optional[ExecutionPlan] = None
@@ -125,7 +124,7 @@ def plan_execution(
         # Build a DAG of Tasks that we actually need to execute
         # this allows us to prune subtrees that will come
         # from pre-computed values (values paramter or cache)
-        unvisited = deque([solved_dependency_cache.tasks[solved.dependency]])
+        unvisited = deque((solved_dependency_cache.root_task,))
         dependency_counts: TaskDependencyCounts = {}
 
         while unvisited:
@@ -156,8 +155,7 @@ def plan_execution(
         )
 
         solved.container_cache = SolvedDependantCache(
-            tasks=solved_dependency_cache.tasks,
-            dependency_dag=solved_dependency_cache.dependency_dag,
+            root_task=solved_dependency_cache.root_task,
             task_dependency_dag=solved_dependency_cache.task_dependency_dag,
             task_dependant_dag=solved_dependency_cache.task_dependant_dag,
             execution_plan=execution_plan,

--- a/di/_utils/execution_planning.py
+++ b/di/_utils/execution_planning.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import deque
 from typing import (
     AbstractSet,
@@ -19,9 +21,14 @@ from di._utils.task import ExecutionState, Task
 from di.types.dependencies import DependantBase
 from di.types.executor import TaskInfo
 from di.types.providers import DependencyProvider
+from di.types.scopes import Scope
 from di.types.solved import SolvedDependant
 
 Dependency = Any
+
+DependantDeque = Deque[DependantBase[Any]]
+
+Results = Dict[DependantBase[Any], Any]
 
 
 class ExecutionPlan(NamedTuple):
@@ -52,6 +59,7 @@ def plan_execution(
     state: ContainerState,
     solved: SolvedDependant[Any],
     *,
+    execution_scope: Scope,
     validate_scopes: bool = True,
     values: Optional[Mapping[DependencyProvider, Any]] = None,
 ) -> Tuple[
@@ -88,10 +96,9 @@ def plan_execution(
         cache.update(mapping)
     cache.update(user_values)
 
-    to_cache: Deque[DependantBase[Any]] = deque()
-    execution_scope = state.scopes[-1]
+    to_cache: DependantDeque = deque()
 
-    results: Dict[DependantBase[Any], Any] = {}
+    results: Results = {}
 
     # For each dependency, check if we can use a cached value or a user supplied value
     # If so, put that value into our results dict

--- a/di/_utils/scope_map.py
+++ b/di/_utils/scope_map.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Generic, Hashable, List, TypeVar
+from typing import Dict, Generic, Hashable, List, Optional, TypeVar
 
 from di.exceptions import DuplicateScopeError
 from di.types.scopes import Scope
@@ -29,8 +29,8 @@ class ScopeMap(Generic[KT, VT]):
 
     mappings: Dict[Scope, Dict[KT, VT]]
 
-    def __init__(self) -> None:
-        self.mappings = {}
+    def __init__(self, mappings: Optional[Dict[Scope, Dict[KT, VT]]] = None) -> None:
+        self.mappings = mappings if mappings is not None else {}
 
     def set(self, key: KT, value: VT, *, scope: Scope) -> None:
         self.mappings[scope][key] = value
@@ -44,9 +44,7 @@ class ScopeMap(Generic[KT, VT]):
         self.mappings.pop(scope)
 
     def copy(self) -> ScopeMap[KT, VT]:
-        new = type(self)()
-        new.mappings = self.mappings.copy()
-        return new
+        return ScopeMap(self.mappings.copy())
 
     def __repr__(self) -> str:  # pragma: no cover, used only for debugging
         values: List[str] = []

--- a/di/_utils/scope_validation.py
+++ b/di/_utils/scope_validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Collection, Dict
 
 from di.exceptions import ScopeViolationError, UnknownScopeError
 from di.types.dependencies import DependantBase
@@ -26,11 +26,11 @@ def check_scope(dep: DependantBase[Any], scope_idxs: Dict[Scope, int]) -> None:
         )
 
 
-def validate_scopes(scopes: List[Scope], solved: SolvedDependant[Any]) -> None:
+def validate_scopes(scopes: Collection[Scope], solved: SolvedDependant[Any]) -> None:
     """Validate that dependencies all have a valid scope and
     that dependencies only depend on outer scopes or their own scope.
     """
-    scope_idxs = {scope: idx for idx, scope in enumerate(reversed(scopes + [None]))}
+    scope_idxs = {scope: idx for idx, scope in enumerate(reversed([*scopes, None]))}
 
     for dep, params in solved.dag.items():
         check_scope(dep, scope_idxs)

--- a/di/_utils/scope_validation.py
+++ b/di/_utils/scope_validation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Collection, Dict
 
 from di.exceptions import ScopeViolationError, UnknownScopeError

--- a/di/container.py
+++ b/di/container.py
@@ -40,6 +40,7 @@ Dependency = Any
 
 _DependantDag = Dict[DependantBase[Any], Set[DependantBase[Any]]]
 _DependantTaskDag = Dict[Task[Any], Set[Task[Any]]]
+_DependantQueue = Deque[DependantBase[Any]]
 
 
 class Container:
@@ -157,7 +158,7 @@ class Container:
                 )
 
         # Do a DFS of the DAG checking constraints along the way
-        q: Deque[DependantBase[Any]] = deque([dependency])
+        q: _DependantQueue = deque((dependency,))
         while q:
             dep = q.popleft()
             if dep in dep_registry:
@@ -189,8 +190,7 @@ class Container:
             for predecessor_task in predecessor_tasks:
                 task_dependant_dag[predecessor_task].add(task)
         container_cache = SolvedDependantCache(
-            dependency_dag=dependency_dag,
-            tasks=tasks,
+            root_task=tasks[dependency],
             task_dependency_dag=task_dependency_dag,
             task_dependant_dag=task_dependant_dag,
         )

--- a/di/container.py
+++ b/di/container.py
@@ -194,11 +194,19 @@ class Container:
             task_dependency_dag=task_dependency_dag,
             task_dependant_dag=task_dependant_dag,
         )
-        return SolvedDependant(
+        solved = SolvedDependant(
             dependency=dependency,
             dag=param_graph,
             container_cache=container_cache,
         )
+        # run plan to populate cache
+        plan_execution(
+            self._state,
+            solved,
+            execution_scope=self._execution_scope,
+            validate_scopes=False,
+        )
+        return solved
 
     def _build_tasks(
         self,

--- a/di/container.py
+++ b/di/container.py
@@ -55,8 +55,6 @@ class Container:
     ) -> None:
         self._context = ContextVar("context")
         state = ContainerState()
-        state.cached_values.add_scope("container")
-        state.cached_values.set(Container, self, scope="container")
         self._context.set(state)
         self._executor = executor or DefaultExecutor()
         self._execution_scope = execution_scope

--- a/di/container.py
+++ b/di/container.py
@@ -4,6 +4,7 @@ from collections import deque
 from contextvars import ContextVar
 from typing import (
     Any,
+    Collection,
     ContextManager,
     Deque,
     Dict,
@@ -60,7 +61,7 @@ class Container:
         return self._context.get()
 
     @property
-    def scopes(self) -> List[Scope]:
+    def scopes(self) -> Collection[Scope]:
         return self._state.scopes
 
     def enter_global_scope(self, scope: Scope) -> FusedContextManager[None]:
@@ -239,7 +240,11 @@ class Container:
             cm = self.enter_local_scope(self._execution_scope)
         with cm:
             results, leaf_tasks, to_cache = plan_execution(
-                self._state, solved, validate_scopes=validate_scopes, values=values
+                self._state,
+                solved,
+                execution_scope=self._execution_scope,
+                validate_scopes=validate_scopes,
+                values=values,
             )
             if not hasattr(self._executor, "execute_sync"):  # pragma: no cover
                 raise TypeError(
@@ -270,7 +275,11 @@ class Container:
             cm = self.enter_local_scope(self._execution_scope)
         async with cm:
             results, leaf_tasks, to_cache = plan_execution(
-                self._state, solved, validate_scopes=validate_scopes, values=values
+                self._state,
+                solved,
+                execution_scope=self._execution_scope,
+                validate_scopes=validate_scopes,
+                values=values,
             )
             if not hasattr(self._executor, "execute_async"):  # pragma: no cover
                 raise TypeError(

--- a/di/dependant.py
+++ b/di/dependant.py
@@ -38,6 +38,7 @@ class Dependant(DependantBase[DependencyType]):
     wire: bool
     autowire: bool
     sync_to_thread: bool
+    __slots__ = ("wire", "autowire", "sync_to_thread", "dependencies", "overrides")
 
     @overload
     def __init__(
@@ -259,6 +260,8 @@ class Dependant(DependantBase[DependencyType]):
 
 class JoinedDependant(DependantBase[DependencyType]):
     """A Dependant that aggregates other dependants without directly depending on them"""
+
+    __slots__ = ("dependant", "siblings", "_dependencies")
 
     _dependencies: Optional[List[DependencyParameter[Any]]]
 

--- a/di/executors.py
+++ b/di/executors.py
@@ -1,11 +1,12 @@
-import concurrent.futures
+from __future__ import annotations
+
 import typing
 from collections import deque
 
 import anyio
 import anyio.abc
 
-from di._utils.concurrency import callable_in_thread_pool, curry_context
+from di._utils.concurrency import callable_in_thread_pool
 from di.types.executor import AsyncExecutor, AsyncTaskInfo, SyncExecutor, TaskInfo
 
 TaskQueue = typing.Deque[TaskInfo]
@@ -53,49 +54,9 @@ class SimpleAsyncExecutor(AsyncExecutor):
                     q.append(newtask)
 
 
-TaskCall = typing.Callable[[], typing.Iterable[typing.Optional[TaskInfo]]]
-TaskCallback = typing.Callable[[], None]
-
-
-class ConcurrentSyncExecutor(AsyncExecutor):
-    def execute_sync(self, tasks: typing.Iterable[TaskInfo]) -> None:
-        futures: typing.Set[concurrent.futures.Future[None]] = set()
-        q: typing.Deque[typing.Optional[TaskInfo]] = deque(tasks)
-        with concurrent.futures.ThreadPoolExecutor() as exec:
-            while True:
-                # remove all completed futures
-                _, futures = concurrent.futures.wait(
-                    futures, return_when=concurrent.futures.FIRST_COMPLETED
-                )
-                newtasks = list(q)
-                q.clear()
-                for task in newtasks:
-                    if task is None:
-                        for future in concurrent.futures.as_completed(futures):
-                            future.result()
-                        return
-                    if isinstance(task, AsyncTaskInfo):
-                        raise TypeError(
-                            "Cannot execute async dependencies in execute_sync"
-                        )
-                    if (
-                        getattr(task.dependant, "sync_to_thread", False) is True
-                    ):  # instance of Dependant
-                        # Use a double closure to bind the value of task in the loop
-                        def make_call(task_call: TaskCall) -> TaskCallback:
-                            def call() -> None:
-                                q.extend(task_call())
-
-                            return call
-
-                        futures.add(exec.submit(curry_context(make_call(task.task))))
-                    else:
-                        q.extend(task.task())
-
-
 async def _async_worker(
     task: TaskInfo,
-    send: typing.Callable[[typing.Optional[TaskInfo]], typing.Awaitable[None]],
+    taskgroup: anyio.abc.TaskGroup,
 ) -> None:
     if isinstance(task, AsyncTaskInfo):
         newtasks = await task.task()
@@ -107,31 +68,16 @@ async def _async_worker(
         newtasks = task.task()
     for taskinfo in newtasks:
         if taskinfo is None:
-            await send(None)
-            return
-        await send(taskinfo)
-
-
-Streams = typing.Tuple[
-    anyio.abc.ObjectSendStream[typing.Optional[TaskInfo]],
-    anyio.abc.ObjectReceiveStream[typing.Optional[TaskInfo]],
-]
+            continue
+        taskgroup.start_soon(_async_worker, taskinfo, taskgroup)
 
 
 class ConcurrentAsyncExecutor(AsyncExecutor):
     async def execute_async(self, tasks: typing.Iterable[TaskInfo]) -> None:
-        streams = typing.cast(Streams, anyio.create_memory_object_stream(float("inf")))
-        send, receive = streams
-        for task in tasks:
-            await send.send(task)
-        async with send, receive:
-            async with anyio.create_task_group() as taskgroup:
-                while True:
-                    newtask = await receive.receive()
-                    if newtask is None:
-                        return None
-                    taskgroup.start_soon(_async_worker, newtask, send.send)
+        async with anyio.create_task_group() as taskgroup:
+            for task in tasks:
+                taskgroup.start_soon(_async_worker, task, taskgroup)
 
 
-class DefaultExecutor(ConcurrentAsyncExecutor, ConcurrentSyncExecutor):
+class DefaultExecutor(ConcurrentAsyncExecutor, SimpleSyncExecutor):
     pass

--- a/di/types/dependencies.py
+++ b/di/types/dependencies.py
@@ -14,13 +14,15 @@ DependencyType = TypeVar("DependencyType")
 T = TypeVar("T")
 
 
-class DependantBase(Generic[DependencyType], abc.ABC):
+class DependantBase(Generic[DependencyType], metaclass=abc.ABCMeta):
     """A dependant is an object that can provide the container with:
     - A hash, to compare itself against other dependants
     - A scope
     - A callable that can be used to assemble itself
     - The dependants that correspond to the keyword arguments of that callable
     """
+
+    __slots__ = ("call", "scope", "share")
 
     call: Optional[DependencyProviderType[DependencyType]]
     scope: Scope
@@ -75,11 +77,8 @@ class DependantBase(Generic[DependencyType], abc.ABC):
         return f"{self.__class__.__name__}(call={self.call}, scope={self.scope}{share})"
 
 
-# this could be a NamedTuple
-# but https://github.com/python/mypy/issues/685
-# we need the generic type
-# so we can use it for DependantBase and Task
 @dataclass
 class DependencyParameter(Generic[DependencyType]):
+    __slots__ = ("dependency", "parameter")
     dependency: DependencyType
     parameter: Optional[inspect.Parameter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.28.10"
+version = "0.29.0"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import pytest
 
 from di import Container, Dependant, Depends
@@ -33,31 +31,6 @@ def test_bind():
         # when we exit the request scope, the bind of value=1 gets cleared
         r = container.execute_sync(container.solve(Dependant(endpoint)))
         assert r == 0  # back to the default value
-
-
-def inject1() -> int:
-    return 1  # pragma: no cover
-
-
-def inject2() -> int:
-    return 2  # pragma: no cover
-
-
-def inject3() -> int:
-    return 3  # pragma: no cover
-
-
-async def endpoint2(
-    v1: int = Depends(inject1), v2: int = Depends(inject2), v3: int = Depends(inject3)
-) -> Tuple[int, int, int]:
-    return v1, v2, v3
-
-
-async def run_endpoint2(expected: Tuple[int, int, int], container: Container):
-    async with container.enter_local_scope("request"):
-        with container.bind(Dependant(lambda: expected[2]), inject3):
-            got = await container.execute_async(container.solve(Dependant(endpoint2)))
-    assert expected == got, (expected, got)
 
 
 def raises_exception() -> None:

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,6 +1,5 @@
 from typing import Tuple
 
-import anyio
 import pytest
 
 from di import Container, Dependant, Depends
@@ -59,21 +58,6 @@ async def run_endpoint2(expected: Tuple[int, int, int], container: Container):
         with container.bind(Dependant(lambda: expected[2]), inject3):
             got = await container.execute_async(container.solve(Dependant(endpoint2)))
     assert expected == got, (expected, got)
-
-
-@pytest.mark.anyio
-async def test_concurrent_binds():
-    """We can bind different values at the same time as long as we are within
-    different local scopes
-    """
-    container = Container()
-    async with container.enter_local_scope("app-local"):
-        container.bind(Dependant(lambda: -10), inject1)
-        async with container.enter_global_scope("app-global"):
-            container.bind(Dependant(lambda: -20), inject2)
-            async with anyio.create_task_group() as tg:
-                for i in range(10):
-                    tg.start_soon(run_endpoint2, (-10, -20, i), container)
 
 
 def raises_exception() -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -15,11 +15,11 @@ def test_execution_scope() -> None:
 
 def test_scopes_property() -> None:
     container = Container()
-    assert container.scopes == []
+    assert list(container.scopes) == []
     with container.enter_global_scope("test"):
-        assert container.scopes == ["test"]
+        assert list(container.scopes) == ["test"]
         with container.enter_local_scope("another"):
-            assert container.scopes == ["test", "another"]
+            assert list(container.scopes) == ["test", "another"]
 
 
 def test_binds_property():

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -283,51 +283,6 @@ async def test_concurrency_async(dep1: Any, dep2: Any):
     await container.execute_async(container.solve(Dependant(collector)))
 
 
-@pytest.mark.parametrize(
-    "dep1",
-    [
-        sync_callable_func_slow,
-        sync_gen_func_slow,
-        SyncCallableClsSlow(),
-        SyncGenClsSlow(),
-    ],
-    ids=[
-        "sync_callable_func",
-        "sync_gen_func",
-        "SyncCallableCls",
-        "SyncGenCls",
-    ],
-)
-@pytest.mark.parametrize(
-    "dep2",
-    [
-        sync_callable_func_slow,
-        sync_gen_func_slow,
-        SyncCallableClsSlow(),
-        SyncGenClsSlow(),
-    ],
-    ids=[
-        "sync_callable_func",
-        "sync_gen_func",
-        "SyncCallableCls",
-        "SyncGenCls",
-    ],
-)
-def test_concurrency_sync(dep1: Any, dep2: Any):
-    container = Container()
-
-    counter = Counter()
-    container.bind(Dependant(lambda: counter), Counter)
-
-    def collector(
-        a: None = Depends(dep1, share=False, sync_to_thread=True),
-        b: None = Depends(dep2, share=False, sync_to_thread=True),
-    ):
-        ...
-
-    container.execute_sync(container.solve(Dependant(collector)))
-
-
 @pytest.mark.anyio
 async def test_concurrent_executions_do_not_share_results():
     """If the same solved depedant is executed twice concurrently we should not

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -4,18 +4,11 @@ from typing import Iterable, Optional
 import pytest
 
 from di.dependant import Dependant
-from di.executors import (
-    ConcurrentSyncExecutor,
-    DefaultExecutor,
-    SimpleAsyncExecutor,
-    SimpleSyncExecutor,
-)
+from di.executors import DefaultExecutor, SimpleAsyncExecutor, SimpleSyncExecutor
 from di.types.executor import AsyncTaskInfo, SyncExecutor, SyncTaskInfo, TaskInfo
 
 
-@pytest.mark.parametrize(
-    "exc_cls", [DefaultExecutor, SimpleSyncExecutor, ConcurrentSyncExecutor]
-)
+@pytest.mark.parametrize("exc_cls", [DefaultExecutor, SimpleSyncExecutor])
 def test_executing_async_dependencies_in_sync_executor(
     exc_cls: typing.Type[SyncExecutor],
 ):


### PR DESCRIPTION
- Alias type annotations
- Use PEP 563 type annotations
- Simplify ConcurrentAsyncExecutor
- Optimize DAG building and execution by minimizing attribute access and removing redundant checks
- Don't automatically convert Scope keys to list
- Add `__slots__` to various classes w/ heavy attribute access
- Remove ConcurrentAsyncExecutor, it is not needed and can be implemented by users