### PR TITLE
perf: use graphlib2 as dependency resolution backend

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,20 +1,5 @@
-Copyright (c) 2012-2021 Scott Chacon and others
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/di/_utils/execution_planning.py
+++ b/di/_utils/execution_planning.py
@@ -8,7 +8,6 @@ from typing import (
     Deque,
     Dict,
     Iterable,
-    List,
     Mapping,
     NamedTuple,
     Optional,
@@ -17,93 +16,51 @@ from typing import (
     Union,
 )
 
+from graphlib2 import TopologicalSorter
+
 from di._utils.scope_validation import validate_scopes
-from di._utils.task import ExecutionState, Task
-from di.api.dependencies import DependantBase
-from di.api.executor import TaskInfo
+from di._utils.task import AsyncTask, ExecutionState, SyncTask, gather_new_tasks
+from di.api.executor import State as ExecutorState
+from di.api.executor import Task as ExecutorTask
 from di.api.providers import DependencyProvider
 from di.api.scopes import Scope
 from di.api.solved import SolvedDependant
 
 Dependency = Any
 
-TaskDeque = Deque[Task]
+TaskCacheDeque = Deque[Tuple[int, Scope]]
 
-Results = Dict[Task, Any]
+Results = Dict[int, Any]
+
+Task = Union[AsyncTask, SyncTask]
 
 TaskDependencyCounts = Dict[Task, int]
-
-
-class ExecutionPlan(NamedTuple):
-    """Cache of the execution plan, stored within SolvedDependantCache"""
-
-    cache_key: AbstractSet[Task]
-    # mapping of which dependencies require computation for each dependant
-    # it is possible that some of them were passed by value or cached
-    # and hence do not require computation
-    task_dependant_dag: Mapping[Task, Iterable[Task]]
-    # count of how many uncompomputed dependencies each dependant has
-    # this is used to keep track of what dependencies are now available for computation
-    dependency_counts: Dict[Task, int]
-    leaf_tasks: Iterable[Task]  # these are the tasks w/ no dependencies
 
 
 class SolvedDependantCache(NamedTuple):
     """Private data that the Container attaches to SolvedDependant"""
 
-    root_task: Task
-    task_dependency_dag: Mapping[Task, Set[Task]]
-    task_dependant_dag: Mapping[Task, Set[Task]]
-    execution_plan: Optional[ExecutionPlan]
-    cacheable_tasks: AbstractSet[Task]
-    cached_tasks: AbstractSet[Task]
+    root_task: int
+    topological_sorter: TopologicalSorter[Task]
+    cacheable_tasks: AbstractSet[int]
+    cached_tasks: Iterable[Tuple[int, Scope]]
     validated_scopes: Set[Tuple[Scope, ...]]
-    call_map: Mapping[DependencyProvider, Set[Task]]
-
-
-def make_execution_plan(
-    resolved_tasks: AbstractSet[Task],
-    root_task: Task,
-    task_dependency_dag: Mapping[Task, Set[Task]],
-    task_dependant_dag: Mapping[Task, Set[Task]],
-) -> ExecutionPlan:
-    # Build a DAG of Tasks that we actually need to execute
-    # this allows us to prune subtrees that will come
-    # from pre-computed values (values paramter or cache)
-    unvisited = deque((root_task,))
-    dependency_counts: TaskDependencyCounts = {}
-    while unvisited:
-        task = unvisited.pop()
-        # if the dependency is cached or was provided by value
-        # we don't need to compute it or any of it's dependencies
-        if task in resolved_tasks:
-            continue
-        # we can also skip this dep if it's already been accounted for
-        if task in dependency_counts:
-            continue
-        # otherwise, we add it to our DAG and visit it's children
-        dependency_counts[task] = 0
-        for predecessor_task in task_dependency_dag[task]:
-            if predecessor_task not in resolved_tasks:
-                dependency_counts[task] += 1
-                if predecessor_task not in dependency_counts:
-                    unvisited.append(predecessor_task)
-
-    return ExecutionPlan(
-        cache_key=frozenset(resolved_tasks),
-        task_dependant_dag=task_dependant_dag,
-        dependency_counts=dependency_counts,
-        leaf_tasks=[task for task, count in dependency_counts.items() if count == 0],
-    )
+    call_map: Mapping[DependencyProvider, Iterable[int]]
 
 
 def plan_execution(
     stacks: Mapping[Scope, Union[AsyncExitStack, ExitStack]],
-    cached_values: Mapping[DependantBase[Any], Any],
+    cached_values: Mapping[int, Any],
     solved: SolvedDependant[Any],
     *,
     values: Optional[Mapping[DependencyProvider, Any]] = None,
-) -> Tuple[Dict[Task, Any], List[TaskInfo], Iterable[Task], Task]:
+) -> Tuple[
+    Dict[int, Any],
+    Iterable[ExecutorTask],
+    ExecutorState,
+    Iterable[Tuple[int, Scope]],
+    int,
+]:
     """Re-use or create an ExecutionPlan"""
     # This function is a hot loop
     # It is run for every execution, and even with the cache it can be a bottleneck
@@ -119,43 +76,34 @@ def plan_execution(
         solved_dependency_cache.validated_scopes.add(scopes)
 
     results: Results = {}
-    for call, value in user_values.items():
-        for task in solved_dependency_cache.call_map[call]:
-            results[task] = value
+    call_map = solved_dependency_cache.call_map
+    for call in user_values.keys() & call_map.keys():
+        value = user_values[call]
+        for task_id in call_map[call]:
+            results[task_id] = value
 
-    to_cache: TaskDeque = deque()
+    to_cache: TaskCacheDeque = deque()
+    cacheable_tasks = solved_dependency_cache.cacheable_tasks
+    add_to_cache = to_cache.append
 
-    for task in solved_dependency_cache.cached_tasks:
-        if task.dependant in cached_values:
-            results[task] = cached_values[task.dependant]
-        elif task in solved_dependency_cache.cacheable_tasks:
-            to_cache.append(task)
+    for task_id, scope in solved_dependency_cache.cached_tasks:
+        if task_id in cached_values:
+            results[task_id] = cached_values[task_id]
+        elif task_id in cacheable_tasks:
+            add_to_cache((task_id, scope))
 
-    execution_plan = solved_dependency_cache.execution_plan
-    resolved_tasks = results.keys()
-
-    # Check if we can re-use the existing plan (if any) or create a new one
-    if execution_plan is None or execution_plan.cache_key != resolved_tasks:
-        execution_plan = make_execution_plan(
-            resolved_tasks,
-            solved_dependency_cache.root_task,
-            solved_dependency_cache.task_dependency_dag,
-            solved_dependency_cache.task_dependant_dag,
-        )
-        solved.container_cache = solved_dependency_cache._replace(
-            execution_plan=execution_plan
-        )
+    ts = solved_dependency_cache.topological_sorter.copy()
 
     execution_state = ExecutionState(
         stacks=stacks,
         results=results,
-        dependency_counts=execution_plan.dependency_counts.copy(),
-        dependants=execution_plan.task_dependant_dag,
+        toplogical_sorter=ts,
     )
 
-    return (
+    return (  # type: ignore[return-value]
         results,
-        [t.as_executor_task(execution_state) for t in execution_plan.leaf_tasks],
+        gather_new_tasks(execution_state),
+        execution_state,
         to_cache,
         solved_dependency_cache.root_task,
     )

--- a/di/_utils/state.py
+++ b/di/_utils/state.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Optional, Type, Union, cast
 
 from di._utils.scope_map import ScopeMap
 from di._utils.types import FusedContextManager
-from di.api.dependencies import DependantBase
 from di.api.scopes import Scope
 
 
@@ -15,7 +14,7 @@ class ContainerState:
 
     def __init__(
         self,
-        cached_values: ScopeMap[DependantBase[Any], Any],
+        cached_values: ScopeMap[int, Any],
         stacks: Dict[Scope, Union[AsyncExitStack, ExitStack]],
     ) -> None:
         self.cached_values = cached_values

--- a/di/_utils/task.py
+++ b/di/_utils/task.py
@@ -1,50 +1,78 @@
 from __future__ import annotations
 
-import functools
-from collections import deque
+import threading
 from contextlib import AsyncExitStack, ExitStack, asynccontextmanager, contextmanager
 from typing import (
     Any,
-    Awaitable,
     Deque,
     Dict,
+    Generator,
     Iterable,
     Mapping,
-    MutableMapping,
     Optional,
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
+
+from graphlib2 import TopologicalSorter
 
 from di._utils.inspect import is_async_gen_callable, is_gen_callable
 from di.api.dependencies import DependantBase
-from di.api.executor import AsyncTaskInfo, SyncTaskInfo, TaskInfo
+from di.api.executor import AsyncTask as ExecutorAsyncTask
+from di.api.executor import State
+from di.api.executor import SyncTask as ExecutorSyncTask
+from di.api.executor import Task as ExecutorTask
 from di.api.providers import DependencyProvider
 from di.api.scopes import Scope
 from di.exceptions import IncompatibleDependencyError
 
 
-class ExecutionState:
-    __slots__ = ("stacks", "results", "dependency_counts", "dependants", "remaining")
+class ExecutionState(State):
+    __slots__ = (
+        "stacks",
+        "results",
+        "toplogical_sorter",
+        "lock",
+    )
 
     def __init__(
         self,
         stacks: Mapping[Scope, Union[AsyncExitStack, ExitStack]],
-        results: Dict[Task, Any],
-        dependency_counts: MutableMapping[Task, int],
-        dependants: Mapping[Task, Iterable[Task]],
+        results: Dict[int, Any],
+        toplogical_sorter: TopologicalSorter[Union[AsyncTask, SyncTask]],
     ):
         self.stacks = stacks
         self.results = results
-        self.dependency_counts = dependency_counts
-        self.dependants = dependants
-        self.remaining = len(self.dependency_counts)
+        self.toplogical_sorter = toplogical_sorter
+        self.lock = threading.Lock()
 
 
 DependencyType = TypeVar("DependencyType")
 
-TaskQueue = Deque[Optional[TaskInfo]]
+TaskQueue = Deque[Optional[ExecutorTask]]
+
+
+def gather_new_tasks(
+    state: ExecutionState,
+) -> Generator[Optional[ExecutorTask], None, None]:
+    """Look amongst our dependants to see if any of them are now dependency free"""
+    ts = state.toplogical_sorter
+    res = state.results
+    done = ts.done_by_id
+    get_ready = ts.get_ready
+    while ts.is_active():
+        ready = get_ready()
+        if not ready:
+            break
+        for t in ready:
+            if t.dependant_id in res:
+                done(t.dependant_id)
+            else:
+                yield t
+    if not ts.is_active():
+        yield None
 
 
 class Task:
@@ -54,15 +82,17 @@ class Task:
         "positional_parameters",
         "keyword_parameters",
         "scope",
+        "dependant_id",
     )
     call: DependencyProvider
     scope: Scope
+    dependant_id: int
 
     def __init__(
         self,
         dependant: DependantBase[Any],
-        positional_parameters: Iterable[Task],
-        keyword_parameters: Mapping[str, Task],
+        positional_parameters: Iterable[int],
+        keyword_parameters: Iterable[Tuple[str, int]],
     ) -> None:
         self.dependant = dependant
         self.scope = self.dependant.scope
@@ -70,71 +100,40 @@ class Task:
         self.call = dependant.call
         self.positional_parameters = positional_parameters
         self.keyword_parameters = keyword_parameters
-
-    def compute(
-        self,
-        state: ExecutionState,
-    ) -> Union[Awaitable[Iterable[Optional[TaskInfo]]], Iterable[Optional[TaskInfo]]]:
-        """Compute this dependency within the context of the current state"""
-        raise NotImplementedError
-
-    def as_executor_task(self, state: ExecutionState) -> TaskInfo:
-        """Bind the state and return either an AsyncTaskInfo or SyncTaskInfo"""
-        raise NotImplementedError
+        self.dependant_id = None  # type: ignore  # gets set after construction by the Container
 
     def gather_params(
-        self, results: Dict[Task, Any]
+        self, results: Dict[int, Any]
     ) -> Tuple[Iterable[Any], Mapping[str, Any]]:
         """Gather all parameters (aka *args and **kwargs) needed for computation"""
         return (
-            (results[t] for t in self.positional_parameters),
-            {k: results[t] for k, t in self.keyword_parameters.items()},
+            (results[t_id] for t_id in self.positional_parameters),
+            {k: results[t_id] for k, t_id in self.keyword_parameters},
         )
-
-    def gather_new_tasks(self, state: ExecutionState) -> Iterable[Optional[TaskInfo]]:
-        """Look amongst our dependants to see if any of them are now dependency free"""
-        new_tasks: TaskQueue = deque()
-        for dependant in state.dependants[self]:
-            v = state.dependency_counts[dependant]
-            if v == 1:
-                # this dependant has no further dependencies, so we can compute it now
-                new_tasks.append(dependant.as_executor_task(state))
-                state.dependency_counts[dependant] = 0
-            else:
-                state.dependency_counts[dependant] = v - 1
-        state.remaining -= 1
-        if state.remaining == 0:
-            new_tasks.append(None)
-        return new_tasks
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({repr(self.dependant)})"
 
 
-class AsyncTask(Task):
+class AsyncTask(Task, ExecutorAsyncTask):
     __slots__ = ("is_generator",)
 
     def __init__(
         self,
         dependant: DependantBase[Any],
-        positional_parameters: Iterable[Task],
-        keyword_parameters: Mapping[str, Task],
+        positional_parameters: Iterable[int],
+        keyword_parameters: Iterable[Tuple[str, int]],
     ) -> None:
         super().__init__(dependant, positional_parameters, keyword_parameters)
         self.is_generator = is_async_gen_callable(self.call)
         if self.is_generator:
             self.call = asynccontextmanager(self.call)  # type: ignore[arg-type]
 
-    def as_executor_task(self, state: ExecutionState) -> AsyncTaskInfo:
-        return AsyncTaskInfo(
-            dependant=self.dependant,
-            task=functools.partial(self.compute, state),
-        )
-
     async def compute(
         self,
-        state: ExecutionState,
-    ) -> Iterable[Optional[TaskInfo]]:
+        state: State,
+    ) -> Iterable[Optional[ExecutorTask]]:
+        state = cast(ExecutionState, state)
         args, kwargs = self.gather_params(state.results)
 
         if self.is_generator:
@@ -145,47 +144,41 @@ class AsyncTask(Task):
                     f"The dependency {self.dependant} is an awaitable dependency"
                     f" and canot be used in the sync scope {self.dependant.scope}"
                 )
-            state.results[self] = await enter(
+            state.results[self.dependant_id] = await enter(
                 self.call(*args, **kwargs)  # type: ignore[arg-type]
             )
         else:
-            state.results[self] = await self.call(*args, **kwargs)  # type: ignore[misc]
+            state.results[self.dependant_id] = await self.call(*args, **kwargs)  # type: ignore[misc]
+        state.toplogical_sorter.done_by_id(self.dependant_id)
+        return gather_new_tasks(state)
 
-        return self.gather_new_tasks(state)
 
-
-class SyncTask(Task):
+class SyncTask(Task, ExecutorSyncTask):
     __slots__ = ("is_generator",)
 
     def __init__(
         self,
         dependant: DependantBase[Any],
-        positional_parameters: Iterable[Task],
-        keyword_parameters: Mapping[str, Task],
+        positional_parameters: Iterable[int],
+        keyword_parameters: Iterable[Tuple[str, int]],
     ) -> None:
         super().__init__(dependant, positional_parameters, keyword_parameters)
         self.is_generator = is_gen_callable(self.call)
         if self.is_generator:
             self.call = contextmanager(self.call)  # type: ignore[arg-type]
 
-    def as_executor_task(self, state: ExecutionState) -> SyncTaskInfo:
-        return SyncTaskInfo(
-            dependant=self.dependant,
-            task=functools.partial(self.compute, state),
-        )
-
     def compute(
         self,
-        state: ExecutionState,
-    ) -> Iterable[Optional[TaskInfo]]:
-
+        state: State,
+    ) -> Iterable[Optional[ExecutorTask]]:
+        state = cast(ExecutionState, state)
         args, kwargs = self.gather_params(state.results)
 
         if self.is_generator:
-            state.results[self] = state.stacks[self.scope].enter_context(
+            state.results[self.dependant_id] = state.stacks[self.scope].enter_context(
                 self.call(*args, **kwargs)  # type: ignore[arg-type]
             )
         else:
-            state.results[self] = self.call(*args, **kwargs)
-
-        return self.gather_new_tasks(state)
+            state.results[self.dependant_id] = self.call(*args, **kwargs)
+        state.toplogical_sorter.done_by_id(self.dependant_id)
+        return gather_new_tasks(state)

--- a/di/api/executor.py
+++ b/di/api/executor.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import sys
-import typing
-from typing import Any, Iterable, Union
+from typing import Any, Iterable, Optional, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
@@ -12,34 +11,36 @@ else:
 from di.api.dependencies import DependantBase
 
 
-class AsyncTaskInfo(typing.NamedTuple):
+class State:
+    __slots__ = ()
+
+
+class AsyncTask:
+    __slots__ = ()
     dependant: DependantBase[Any]
-    task: AsyncTask
 
-
-class SyncTaskInfo(typing.NamedTuple):
-    dependant: DependantBase[Any]
-    task: SyncTask
-
-
-TaskInfo = Union[AsyncTaskInfo, SyncTaskInfo]
-
-
-class AsyncTask(Protocol):
-    async def __call__(self) -> Iterable[Union[None, TaskInfo]]:
+    async def compute(self, state: State) -> Iterable[Union[None, Task]]:
         ...
 
 
-class SyncTask(Protocol):
-    def __call__(self) -> Iterable[Union[None, TaskInfo]]:
+class SyncTask:
+    __slots__ = ()
+    dependant: DependantBase[Any]
+
+    def compute(self, state: State) -> Iterable[Union[None, Task]]:
         ...
+
+
+Task = Union[AsyncTask, SyncTask]
 
 
 class SyncExecutor(Protocol):
-    def execute_sync(self, tasks: Iterable[TaskInfo]) -> None:
+    def execute_sync(self, tasks: Iterable[Optional[Task]], state: State) -> None:
         raise NotImplementedError
 
 
 class AsyncExecutor(Protocol):
-    async def execute_async(self, tasks: Iterable[TaskInfo]) -> None:
+    async def execute_async(
+        self, tasks: Iterable[Optional[Task]], state: State
+    ) -> None:
         raise NotImplementedError

--- a/di/container.py
+++ b/di/container.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import contextvars
-from collections import defaultdict, deque
+from collections import deque
 from contextlib import contextmanager
 from types import TracebackType
 from typing import (
     Any,
     Collection,
     ContextManager,
-    DefaultDict,
     Deque,
     Dict,
     Generator,
@@ -17,17 +16,19 @@ from typing import (
     Mapping,
     Optional,
     Set,
+    Tuple,
     Type,
     TypeVar,
     Union,
 )
 
-from di._utils.dag import topsort
+from graphlib2 import TopologicalSorter
+
 from di._utils.execution_planning import SolvedDependantCache, plan_execution
 from di._utils.inspect import is_async_gen_callable, is_coroutine_callable
 from di._utils.nullcontext import nullcontext
 from di._utils.state import ContainerState
-from di._utils.task import AsyncTask, SyncTask, Task
+from di._utils.task import AsyncTask, SyncTask
 from di._utils.types import FusedContextManager
 from di.api.dependencies import DependantBase, DependencyParameter
 from di.api.executor import AsyncExecutor, SyncExecutor
@@ -39,9 +40,9 @@ from di.executors import DefaultExecutor
 
 Dependency = Any
 
-_DependantDag = Dict[DependantBase[Any], Set[DependantBase[Any]]]
-_DependantTaskDag = Dict[Task, Set[Task]]
-_CallMap = DefaultDict[DependencyProvider, Set[Task]]
+_Task = Union[AsyncTask, SyncTask]
+
+_DependantTaskDag = Dict[_Task, Set[_Task]]
 _DependantQueue = Deque[DependantBase[Any]]
 _ExecutionCM = FusedContextManager[None]
 _nullcontext = nullcontext(None)
@@ -51,11 +52,23 @@ __all__ = ("BaseContainer", "Container", "ContainerState")
 
 
 class _ContainerCommon:
-    __slots__ = ("_executor", "_execution_scope", "_binds")
+    __slots__ = ("_executor", "_execution_scope", "_binds", "_dep_registry")
 
     _executor: Union[SyncExecutor, AsyncExecutor]
     _execution_scope: Scope
     _binds: Dict[DependencyProvider, DependantBase[Any]]
+    _dep_registry: Dict[DependantBase[Any], int]
+
+    def __init__(self) -> None:
+        self._dep_registry = {}
+
+    def _register_new_dep(self, task: _Task) -> int:
+        dep_id = self._dep_registry.get(task.dependant, None)
+        if dep_id is not None:
+            return dep_id
+        res = len(self._dep_registry)
+        self._dep_registry[task.dependant] = res
+        return res
 
     @property
     def binds(self) -> Mapping[DependencyProvider, DependantBase[Any]]:
@@ -111,7 +124,6 @@ class _ContainerCommon:
 
         # Mapping of already seen dependants to itself for hash based lookups
         dep_registry: Dict[DependantBase[Any], DependantBase[Any]] = {}
-
         # DAG mapping dependants to their dependendencies
         dep_dag: Dict[DependantBase[Any], List[DependantBase[Any]]] = {}
 
@@ -166,34 +178,39 @@ class _ContainerCommon:
                     if predecessor_dep not in dep_registry:
                         q.append(predecessor_dep)
 
-        # Build tasks and SolvedDependency
-        tasks = self._build_tasks(param_graph, topsort(dep_dag))
-        dependency_dag: _DependantDag = {
-            dep: set(predecessor_deps) for dep, predecessor_deps in dep_dag.items()
-        }
+        # Order the Dependant's topologically so that we can create Tasks
+        # with references to all of their children
+        dep_topsort = TopologicalSorter(dep_dag).static_order()
+        # Create a seperate TopologicalSorter to hold the Tasks
+        ts: TopologicalSorter[_Task] = TopologicalSorter(
+            node_id_factory=self._register_new_dep
+        )
+        tasks = self._build_tasks(param_graph, dep_topsort, ts)
+        for dep, predecessors in dep_dag.items():
+            ts.add(tasks[dep], *(tasks[p] for p in predecessors))
+        ts.prepare()
         task_dependency_dag: _DependantTaskDag = {
             tasks[dep]: {tasks[predecessor_dep] for predecessor_dep in predecessor_deps}
-            for dep, predecessor_deps in dependency_dag.items()
+            for dep, predecessor_deps in dep_dag.items()
         }
-        task_dependant_dag: _DependantTaskDag = {tasks[dep]: set() for dep in dep_dag}
-        call_map: _CallMap = defaultdict(set)
-        for task, predecessor_tasks in task_dependency_dag.items():
-            call_map[task.call].add(task)
-            for predecessor_task in predecessor_tasks:
-                task_dependant_dag[predecessor_task].add(task)
+        call_map: Dict[DependencyProvider, Set[int]] = {}
+        for t in task_dependency_dag:
+            if t.call not in call_map:
+                call_map[t.call] = set()
+            call_map[t.call].add(t.dependant_id)
         container_cache = SolvedDependantCache(
-            root_task=tasks[dependency],
-            task_dependency_dag=task_dependency_dag,
-            task_dependant_dag=task_dependant_dag,
+            root_task=tasks[dependency].dependant_id,
+            topological_sorter=ts,
             cacheable_tasks={
-                tasks[d]
-                for d in dependency_dag
+                tasks[d].dependant_id
+                for d in dep_dag
                 if d.scope != self._execution_scope and d.share
             },
-            cached_tasks={tasks[d] for d in dependency_dag if d.share},
-            execution_plan=None,
+            cached_tasks=tuple(
+                {(tasks[d].dependant_id, d.scope) for d in dep_dag if d.share}
+            ),
             validated_scopes=set(),
-            call_map=call_map,
+            call_map={k: tuple(v) for k, v in call_map.items()},
         )
         solved = SolvedDependant(
             dependency=dependency,
@@ -208,48 +225,54 @@ class _ContainerCommon:
             DependantBase[Any],
             List[DependencyParameter],
         ],
-        topsorted: List[DependantBase[Any]],
-    ) -> Dict[DependantBase[Any], Union[AsyncTask, SyncTask]]:
-        tasks: Dict[DependantBase[Any], Union[AsyncTask, SyncTask]] = {}
-        for dep in reversed(topsorted):
-            positional: List[Task] = []
-            keyword: Dict[str, Task] = {}
+        topsorted: Iterable[DependantBase[Any]],
+        ts: TopologicalSorter[_Task],
+    ) -> Dict[DependantBase[Any], _Task]:
+        tasks: Dict[DependantBase[Any], _Task] = {}
+        for dep in topsorted:
+            positional: List[int] = []
+            keyword: Dict[str, int] = {}
             for param in dag[dep]:
                 if param.parameter is not None:
                     task = tasks[param.dependency]
                     # prefer positional arguments since those can be unpacked from a generator
                     # saving generation of an intermediate dict
                     if param.parameter.kind is param.parameter.KEYWORD_ONLY:
-                        keyword[param.parameter.name] = task
+                        keyword[param.parameter.name] = task.dependant_id
                     else:
-                        positional.append(task)
+                        positional.append(task.dependant_id)
+
+            positional_parameters = tuple(positional)
+            keyword_parameters = tuple((k, v) for k, v in keyword.items())
 
             if is_async_gen_callable(dep.call) or is_coroutine_callable(dep.call):
-                tasks[dep] = AsyncTask(
+                tasks[dep] = task = AsyncTask(
                     dependant=dep,
-                    positional_parameters=positional,
-                    keyword_parameters=keyword,
+                    positional_parameters=positional_parameters,
+                    keyword_parameters=keyword_parameters,
                 )
             else:
-                tasks[dep] = SyncTask(
+                tasks[dep] = task = SyncTask(
                     dependant=dep,
-                    positional_parameters=positional,
-                    keyword_parameters=keyword,
+                    positional_parameters=positional_parameters,
+                    keyword_parameters=keyword_parameters,
                 )
+            ts.add(task, *(tasks[p.dependency] for p in dag[dep]))
+            task.dependant_id = next(iter(ts.get_ids(task)))
         return tasks
 
     def _update_cache(
         self,
         state: ContainerState,
-        results: Dict[Task, Any],
-        to_cache: Iterable[Task],
+        results: Dict[int, Any],
+        to_cache: Iterable[Tuple[int, Scope]],
     ) -> None:
         cache = state.cached_values.set
         for task in to_cache:
             cache(
-                task.dependant,
-                results[task],
-                scope=task.dependant.scope,
+                task[0],
+                results[task[0]],
+                scope=task[1],
             )
 
     def execute_sync(
@@ -271,7 +294,7 @@ class _ContainerCommon:
             state = state.copy()
             cm = state.enter_scope(self._execution_scope)
         with cm:
-            results, leaf_tasks, to_cache, root_task = plan_execution(
+            results, leaf_tasks, execution_state, to_cache, root_task = plan_execution(
                 stacks=state.stacks,
                 cached_values=state.cached_values.to_mapping(),
                 solved=solved,
@@ -282,7 +305,7 @@ class _ContainerCommon:
                     raise TypeError(
                         "execute_sync requires an executor implementing the SyncExecutor protocol"
                     )
-                self._executor.execute_sync(leaf_tasks)  # type: ignore[union-attr]
+                self._executor.execute_sync(leaf_tasks, execution_state)  # type: ignore[union-attr]
             self._update_cache(state, results, to_cache)
             return results[root_task]  # type: ignore[no-any-return]
 
@@ -301,7 +324,7 @@ class _ContainerCommon:
             state = state.copy()
             cm = state.enter_scope(self._execution_scope)
         async with cm:
-            results, leaf_tasks, to_cache, root_task = plan_execution(
+            results, leaf_tasks, execution_state, to_cache, root_task = plan_execution(
                 stacks=state.stacks,
                 cached_values=state.cached_values.to_mapping(),
                 solved=solved,
@@ -312,7 +335,7 @@ class _ContainerCommon:
                     raise TypeError(
                         "execute_async requires an executor implementing the AsyncExecutor protocol"
                     )
-                await self._executor.execute_async(leaf_tasks)  # type: ignore[union-attr]
+                await self._executor.execute_async(leaf_tasks, execution_state)  # type: ignore[union-attr]
             self._update_cache(state, results, to_cache)
             return results[root_task]  # type: ignore[no-any-return]
 
@@ -331,6 +354,7 @@ class BaseContainer(_ContainerCommon):
         _state: Optional[ContainerState] = None,
         _binds: Optional[Dict[DependencyProvider, DependantBase[Any]]] = None,
     ) -> None:
+        super().__init__()
         self._executor = executor or DefaultExecutor()
         self._execution_scope = execution_scope
         self.__state = _state or ContainerState.initialize()
@@ -424,6 +448,7 @@ class Container(_ContainerCommon):
         _context: Optional[contextvars.ContextVar[ContainerState]] = None,
         _binds: Optional[Dict[DependencyProvider, DependantBase[Any]]] = None,
     ) -> None:
+        super().__init__()
         if _context is None:
             self._context = contextvars.ContextVar(f"{self}._context")
             self._context.set(ContainerState.initialize())

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "anyio"
-version = "3.3.4"
+version = "3.4.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
 optional = false
@@ -13,7 +13,7 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
@@ -63,7 +63,7 @@ testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "p
 
 [[package]]
 name = "black"
-version = "21.10b0"
+version = "21.11b1"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -74,9 +74,9 @@ click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
-regex = ">=2020.1.8"
+regex = ">=2021.4.4"
 tomli = ">=0.2.6,<2.0.0"
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = [
     {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
     {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
@@ -118,7 +118,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.7"
+version = "2.0.8"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "dev"
 optional = false
@@ -160,7 +160,7 @@ test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
-version = "6.1.2"
+version = "6.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -182,7 +182,7 @@ python-versions = "*"
 
 [[package]]
 name = "filelock"
-version = "3.3.2"
+version = "3.4.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -221,6 +221,17 @@ python-dateutil = ">=2.8.1"
 dev = ["twine", "markdown", "flake8", "wheel"]
 
 [[package]]
+name = "graphlib2"
+version = "0.1.1"
+description = "Rust port of the Python stdlib graphlib modules"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+typing-extensions = {version = ">=3", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "h11"
 version = "0.12.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -230,7 +241,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "httpcore"
-version = "0.13.7"
+version = "0.14.3"
 description = "A minimal low-level HTTP client."
 category = "dev"
 optional = false
@@ -238,6 +249,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 anyio = ">=3.0.0,<4.0.0"
+certifi = "*"
 h11 = ">=0.11,<0.13"
 sniffio = ">=1.0.0,<2.0.0"
 
@@ -246,7 +258,7 @@ http2 = ["h2 (>=3,<5)"]
 
 [[package]]
 name = "httpx"
-version = "0.20.0"
+version = "0.21.1"
 description = "The next generation HTTP client."
 category = "dev"
 optional = false
@@ -255,7 +267,7 @@ python-versions = ">=3.6"
 [package.dependencies]
 certifi = "*"
 charset-normalizer = "*"
-httpcore = ">=0.13.3,<0.14.0"
+httpcore = ">=0.14.0,<0.15.0"
 rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
@@ -266,14 +278,14 @@ http2 = ["h2 (>=3,<5)"]
 
 [[package]]
 name = "identify"
-version = "2.3.5"
+version = "2.4.0"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.6.1"
 
 [package.extras]
-license = ["editdistance-s"]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -338,14 +350,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "markdown"
-version = "3.3.4"
+version = "3.3.6"
 description = "Python implementation of Markdown."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 
 [package.extras]
 testing = ["coverage", "pyyaml"]
@@ -494,14 +506,14 @@ attrs = ">=19.2.0"
 
 [[package]]
 name = "packaging"
-version = "21.2"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2,<3"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
@@ -540,7 +552,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.15.0"
+version = "2.16.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -597,7 +609,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pymdown-extensions"
-version = "9.0"
+version = "9.1"
 description = "Extension pack for Python Markdown."
 category = "dev"
 optional = false
@@ -608,11 +620,14 @@ Markdown = ">=3.2"
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
+version = "3.0.6"
 description = "Python parsing module"
 category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -737,7 +752,7 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "rich"
-version = "10.13.0"
+version = "10.15.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "dev"
 optional = false
@@ -747,7 +762,7 @@ python-versions = ">=3.6.2,<4.0.0"
 colorama = ">=0.4.0,<0.5.0"
 commonmark = ">=0.9.0,<0.10.0"
 pygments = ">=2.6.0,<3.0.0"
-typing-extensions = {version = ">=3.7.4,<4.0.0", markers = "python_version < \"3.8\""}
+typing-extensions = {version = ">=3.7.4,<5.0", markers = "python_version < \"3.8\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
@@ -778,7 +793,7 @@ python-versions = "*"
 
 [[package]]
 name = "starlette"
-version = "0.17.0"
+version = "0.17.1"
 description = "The little ASGI library that shines."
 category = "dev"
 optional = false
@@ -930,12 +945,12 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.0,<4"
-content-hash = "aff0f897033b87a3335b774398f5c45b8a58f4e0caf871316de130b81627f2c6"
+content-hash = "d0d68d9fd8498d069f8a3980272e2e261946d75d85f721b23b22c116ef58a3a7"
 
 [metadata.files]
 anyio = [
-    {file = "anyio-3.3.4-py3-none-any.whl", hash = "sha256:4fd09a25ab7fa01d34512b7249e366cd10358cdafc95022c7ff8c8f8a5026d66"},
-    {file = "anyio-3.3.4.tar.gz", hash = "sha256:67da67b5b21f96b9d3d65daa6ea99f5d5282cb09f50eb4456f8fb51dffefc3ff"},
+    {file = "anyio-3.4.0-py3-none-any.whl", hash = "sha256:2855a9423524abcdd652d942f8932fda1735210f77a6b392eafd9ff34d3fe020"},
+    {file = "anyio-3.4.0.tar.gz", hash = "sha256:24adc69309fb5779bc1e06158e143e0b6d2c56b302a3ac3de3083c705a6ed39d"},
 ]
 async-generator = [
     {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
@@ -954,8 +969,8 @@ attrs = [
     {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
 ]
 black = [
-    {file = "black-21.10b0-py3-none-any.whl", hash = "sha256:6eb7448da9143ee65b856a5f3676b7dda98ad9abe0f87fce8c59291f15e82a5b"},
-    {file = "black-21.10b0.tar.gz", hash = "sha256:a9952229092e325fe5f3dae56d81f639b23f7131eb840781947e4b2886030f33"},
+    {file = "black-21.11b1-py3-none-any.whl", hash = "sha256:802c6c30b637b28645b7fde282ed2569c0cd777dbe493a41b6a03c1d903f99ac"},
+    {file = "black-21.11b1.tar.gz", hash = "sha256:a042adbb18b3262faad5aff4e834ff186bb893f95ba3a8013f09de1e5569def2"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1018,8 +1033,8 @@ cfgv = [
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
-    {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
+    {file = "charset-normalizer-2.0.8.tar.gz", hash = "sha256:735e240d9a8506778cd7a453d97e817e536bb1fc29f4f6961ce297b9c7a917b0"},
+    {file = "charset_normalizer-2.0.8-py3-none-any.whl", hash = "sha256:83fcdeb225499d6344c8f7f34684c2981270beacc32ede2e669e94f7fa544405"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -1034,61 +1049,61 @@ commonmark = [
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 coverage = [
-    {file = "coverage-6.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:675adb3b3380967806b3cbb9c5b00ceb29b1c472692100a338730c1d3e59c8b9"},
-    {file = "coverage-6.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95a58336aa111af54baa451c33266a8774780242cab3704b7698d5e514840758"},
-    {file = "coverage-6.1.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d0a595a781f8e186580ff8e3352dd4953b1944289bec7705377c80c7e36c4d6c"},
-    {file = "coverage-6.1.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d3c5f49ce6af61154060640ad3b3281dbc46e2e0ef2fe78414d7f8a324f0b649"},
-    {file = "coverage-6.1.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:310c40bed6b626fd1f463e5a83dba19a61c4eb74e1ac0d07d454ebbdf9047e9d"},
-    {file = "coverage-6.1.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a4d48e42e17d3de212f9af44f81ab73b9378a4b2b8413fd708d0d9023f2bbde4"},
-    {file = "coverage-6.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ffa545230ca2ad921ad066bf8fd627e7be43716b6e0fcf8e32af1b8188ccb0ab"},
-    {file = "coverage-6.1.2-cp310-cp310-win32.whl", hash = "sha256:cd2d11a59afa5001ff28073ceca24ae4c506da4355aba30d1e7dd2bd0d2206dc"},
-    {file = "coverage-6.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:96129e41405887a53a9cc564f960d7f853cc63d178f3a182fdd302e4cab2745b"},
-    {file = "coverage-6.1.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1de9c6f5039ee2b1860b7bad2c7bc3651fbeb9368e4c4d93e98a76358cdcb052"},
-    {file = "coverage-6.1.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:80cb70264e9a1d04b519cdba3cd0dc42847bf8e982a4d55c769b9b0ee7cdce1e"},
-    {file = "coverage-6.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:ba6125d4e55c0b8e913dad27b22722eac7abdcb1f3eab1bd090eee9105660266"},
-    {file = "coverage-6.1.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8492d37acdc07a6eac6489f6c1954026f2260a85a4c2bb1e343fe3d35f5ee21a"},
-    {file = "coverage-6.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:66af99c7f7b64d050d37e795baadf515b4561124f25aae6e1baa482438ecc388"},
-    {file = "coverage-6.1.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ebcc03e1acef4ff44f37f3c61df478d6e469a573aa688e5a162f85d7e4c3860d"},
-    {file = "coverage-6.1.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98d44a8136eebbf544ad91fef5bd2b20ef0c9b459c65a833c923d9aa4546b204"},
-    {file = "coverage-6.1.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:c18725f3cffe96732ef96f3de1939d81215fd6d7d64900dcc4acfe514ea4fcbf"},
-    {file = "coverage-6.1.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c8e9c4bcaaaa932be581b3d8b88b677489975f845f7714efc8cce77568b6711c"},
-    {file = "coverage-6.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:06d009e8a29483cbc0520665bc46035ffe9ae0e7484a49f9782c2a716e37d0a0"},
-    {file = "coverage-6.1.2-cp36-cp36m-win32.whl", hash = "sha256:e5432d9c329b11c27be45ee5f62cf20a33065d482c8dec1941d6670622a6fb8f"},
-    {file = "coverage-6.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:82fdcb64bf08aa5db881db061d96db102c77397a570fbc112e21c48a4d9cb31b"},
-    {file = "coverage-6.1.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:94f558f8555e79c48c422045f252ef41eb43becdd945e9c775b45ebfc0cbd78f"},
-    {file = "coverage-6.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:046647b96969fda1ae0605f61288635209dd69dcd27ba3ec0bf5148bc157f954"},
-    {file = "coverage-6.1.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:cc799916b618ec9fd00135e576424165691fec4f70d7dc12cfaef09268a2478c"},
-    {file = "coverage-6.1.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:62646d98cf0381ffda301a816d6ac6c35fc97aa81b09c4c52d66a15c4bef9d7c"},
-    {file = "coverage-6.1.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:27a3df08a855522dfef8b8635f58bab81341b2fb5f447819bc252da3aa4cf44c"},
-    {file = "coverage-6.1.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:610c0ba11da8de3a753dc4b1f71894f9f9debfdde6559599f303286e70aeb0c2"},
-    {file = "coverage-6.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:35b246ae3a2c042dc8f410c94bcb9754b18179cdb81ff9477a9089dbc9ecc186"},
-    {file = "coverage-6.1.2-cp37-cp37m-win32.whl", hash = "sha256:0cde7d9fe2fb55ff68ebe7fb319ef188e9b88e0a3d1c9c5db7dd829cd93d2193"},
-    {file = "coverage-6.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:958ac66272ff20e63d818627216e3d7412fdf68a2d25787b89a5c6f1eb7fdd93"},
-    {file = "coverage-6.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a300b39c3d5905686c75a369d2a66e68fd01472ea42e16b38c948bd02b29e5bd"},
-    {file = "coverage-6.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d3855d5d26292539861f5ced2ed042fc2aa33a12f80e487053aed3bcb6ced13"},
-    {file = "coverage-6.1.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:586d38dfc7da4a87f5816b203ff06dd7c1bb5b16211ccaa0e9788a8da2b93696"},
-    {file = "coverage-6.1.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a34fccb45f7b2d890183a263578d60a392a1a218fdc12f5bce1477a6a68d4373"},
-    {file = "coverage-6.1.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bc1ee1318f703bc6c971da700d74466e9b86e0c443eb85983fb2a1bd20447263"},
-    {file = "coverage-6.1.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3f546f48d5d80a90a266769aa613bc0719cb3e9c2ef3529d53f463996dd15a9d"},
-    {file = "coverage-6.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fd92ece726055e80d4e3f01fff3b91f54b18c9c357c48fcf6119e87e2461a091"},
-    {file = "coverage-6.1.2-cp38-cp38-win32.whl", hash = "sha256:24ed38ec86754c4d5a706fbd5b52b057c3df87901a8610d7e5642a08ec07087e"},
-    {file = "coverage-6.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:97ef6e9119bd39d60ef7b9cd5deea2b34869c9f0b9777450a7e3759c1ab09b9b"},
-    {file = "coverage-6.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6e5a8c947a2a89c56655ecbb789458a3a8e3b0cbf4c04250331df8f647b3de59"},
-    {file = "coverage-6.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a39590d1e6acf6a3c435c5d233f72f5d43b585f5be834cff1f21fec4afda225"},
-    {file = "coverage-6.1.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9d2c2e3ce7b8cc932a2f918186964bd44de8c84e2f9ef72dc616f5bb8be22e71"},
-    {file = "coverage-6.1.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3348865798c077c695cae00da0924136bb5cc501f236cfd6b6d9f7a3c94e0ec4"},
-    {file = "coverage-6.1.2-cp39-cp39-win32.whl", hash = "sha256:fae3fe111670e51f1ebbc475823899524e3459ea2db2cb88279bbfb2a0b8a3de"},
-    {file = "coverage-6.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:af45eea024c0e3a25462fade161afab4f0d9d9e0d5a5d53e86149f74f0a35ecc"},
-    {file = "coverage-6.1.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:eab14fdd410500dae50fd14ccc332e65543e7b39f6fc076fe90603a0e5d2f929"},
-    {file = "coverage-6.1.2.tar.gz", hash = "sha256:d9a635114b88c0ab462e0355472d00a180a5fbfd8511e7f18e4ac32652e7d972"},
+    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
+    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
+    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
+    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
+    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
+    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
+    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
+    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
+    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
+    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
+    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
+    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
+    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
+    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
+    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
+    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
+    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
+    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
+    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
+    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 distlib = [
     {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
     {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
 ]
 filelock = [
-    {file = "filelock-3.3.2-py3-none-any.whl", hash = "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"},
-    {file = "filelock-3.3.2.tar.gz", hash = "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8"},
+    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
+    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -1098,21 +1113,35 @@ ghp-import = [
     {file = "ghp-import-2.0.2.tar.gz", hash = "sha256:947b3771f11be850c852c64b561c600fdddf794bab363060854c1ee7ad05e071"},
     {file = "ghp_import-2.0.2-py3-none-any.whl", hash = "sha256:5f8962b30b20652cdffa9c5a9812f7de6bcb56ec475acac579807719bf242c46"},
 ]
+graphlib2 = [
+    {file = "graphlib2-0.1.1-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:15ff1b97e0f35fbb6ae3661823096880eeb19ce2ebf36f1ee5233bf1cc61a4e4"},
+    {file = "graphlib2-0.1.1-cp37-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:235abb10496ab22f57c817df37a06cae306742bdb9c27aae1fcbc3149a4e4cc5"},
+    {file = "graphlib2-0.1.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bfdd6955d9c297f33c4da8bbfe6cbcaaad966ef0ab0ca4eb836c11c0ac6963af"},
+    {file = "graphlib2-0.1.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc71285a0a5077b6b3c9c823b50229e46cbeb64e6f42c0fd9f5e9a02ec4820ce"},
+    {file = "graphlib2-0.1.1-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:50b891bc0d21cc8136600f3677225ff401e03a0173b12517e3bb0f60b650f948"},
+    {file = "graphlib2-0.1.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c46d12bea0f30c39f24f24279ce1c70c66a1a06a26abafb2fb02d775babba0e6"},
+    {file = "graphlib2-0.1.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:066a513a4d8c133b8a3fb324ed37e68f96934572a61e432f99a2f0df83a1e240"},
+    {file = "graphlib2-0.1.1-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4a4bbdc4b0b62adcff07fc334a146ed2f2674cbc21b6c5619aff134b30369496"},
+    {file = "graphlib2-0.1.1-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e97b7dd70c33ab3440bde22114c92b6fc1d77fde096b5b81bc98ae4053cec8de"},
+    {file = "graphlib2-0.1.1-cp37-abi3-win32.whl", hash = "sha256:dbb5ebaf9dc945138bf58b3514fc145325e2e16ecbd4747f5c9d61beadb409f3"},
+    {file = "graphlib2-0.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:09cee31c580500333843a8f428db7127290bd01cdd726d27da94eb7abbf0e049"},
+    {file = "graphlib2-0.1.1.tar.gz", hash = "sha256:186ceff3748c85b47e723f85d3691906b1601c2164873d267b876a966dd504c2"},
+]
 h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
     {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
 ]
 httpcore = [
-    {file = "httpcore-0.13.7-py3-none-any.whl", hash = "sha256:369aa481b014cf046f7067fddd67d00560f2f00426e79569d99cb11245134af0"},
-    {file = "httpcore-0.13.7.tar.gz", hash = "sha256:036f960468759e633574d7c121afba48af6419615d36ab8ede979f1ad6276fa3"},
+    {file = "httpcore-0.14.3-py3-none-any.whl", hash = "sha256:9a98d2416b78976fc5396ff1f6b26ae9885efbb3105d24eed490f20ab4c95ec1"},
+    {file = "httpcore-0.14.3.tar.gz", hash = "sha256:d10162a63265a0228d5807964bd964478cbdb5178f9a2eedfebb2faba27eef5d"},
 ]
 httpx = [
-    {file = "httpx-0.20.0-py3-none-any.whl", hash = "sha256:33af5aad9bdc82ef1fc89219c1e36f5693bf9cd0ebe330884df563445682c0f8"},
-    {file = "httpx-0.20.0.tar.gz", hash = "sha256:09606d630f070d07f9ff28104fbcea429ea0014c1e89ac90b4d8de8286c40e7b"},
+    {file = "httpx-0.21.1-py3-none-any.whl", hash = "sha256:208e5ef2ad4d105213463cfd541898ed9d11851b346473539a8425e644bb7c66"},
+    {file = "httpx-0.21.1.tar.gz", hash = "sha256:02af20df486b78892a614a7ccd4e4e86a5409ec4981ab0e422c579a887acad83"},
 ]
 identify = [
-    {file = "identify-2.3.5-py2.py3-none-any.whl", hash = "sha256:ba945bddb4322394afcf3f703fa68eda08a6acc0f99d9573eb2be940aa7b9bba"},
-    {file = "identify-2.3.5.tar.gz", hash = "sha256:6f0368ba0f21c199645a331beb7425d5374376e71bc149e9cb55e45cb45f832d"},
+    {file = "identify-2.4.0-py2.py3-none-any.whl", hash = "sha256:eba31ca80258de6bb51453084bff4a923187cd2193b9c13710f2516ab30732cc"},
+    {file = "identify-2.4.0.tar.gz", hash = "sha256:a33ae873287e81651c7800ca309dc1f84679b763c9c8b30680e16fbfa82f0107"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1135,8 +1164,8 @@ jinja2 = [
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 markdown = [
-    {file = "Markdown-3.3.4-py3-none-any.whl", hash = "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"},
-    {file = "Markdown-3.3.4.tar.gz", hash = "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"},
+    {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},
+    {file = "Markdown-3.3.6.tar.gz", hash = "sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
@@ -1144,6 +1173,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1155,6 +1187,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1166,6 +1201,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
@@ -1178,6 +1216,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1190,6 +1231,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1259,8 +1303,8 @@ outcome = [
     {file = "outcome-1.1.0.tar.gz", hash = "sha256:e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967"},
 ]
 packaging = [
-    {file = "packaging-21.2-py3-none-any.whl", hash = "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"},
-    {file = "packaging-21.2.tar.gz", hash = "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -1275,8 +1319,8 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.15.0-py2.py3-none-any.whl", hash = "sha256:a4ed01000afcb484d9eb8d504272e642c4c4099bbad3a6b27e519bd6a3e928a6"},
-    {file = "pre_commit-2.15.0.tar.gz", hash = "sha256:3c25add78dbdfb6a28a651780d5c311ac40dd17f160eb3954a0c59da40a505a7"},
+    {file = "pre_commit-2.16.0-py2.py3-none-any.whl", hash = "sha256:758d1dc9b62c2ed8881585c254976d66eae0889919ab9b859064fc2fe3c7743e"},
+    {file = "pre_commit-2.16.0.tar.gz", hash = "sha256:fe9897cac830aa7164dbd02a4e7b90cae49630451ce88464bca73db486ba9f65"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
@@ -1299,12 +1343,12 @@ pygments = [
     {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
 ]
 pymdown-extensions = [
-    {file = "pymdown-extensions-9.0.tar.gz", hash = "sha256:01e4bec7f4b16beaba0087a74496401cf11afd69e3a11fe95cb593e5c698ef40"},
-    {file = "pymdown_extensions-9.0-py3-none-any.whl", hash = "sha256:430cc2fbb30cef2df70edac0b4f62614a6a4d2b06462e32da4ca96098b7c1dfb"},
+    {file = "pymdown-extensions-9.1.tar.gz", hash = "sha256:74247f2c80f1d9e3c7242abe1c16317da36c6f26c7ad4b8a7f457f0ec20f0365"},
+    {file = "pymdown_extensions-9.1-py3-none-any.whl", hash = "sha256:b03e66f91f33af4a6e7a0e20c740313522995f69a03d86316b1449766c473d0e"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
@@ -1420,8 +1464,8 @@ rfc3986 = [
     {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
 rich = [
-    {file = "rich-10.13.0-py3-none-any.whl", hash = "sha256:96d15285b64dbf8154e0717298d2fdfdbbe03da26a392632c23820068f06c3b3"},
-    {file = "rich-10.13.0.tar.gz", hash = "sha256:d80fc76f34d819c481a48f73ec9ac396bed3bd6a16ecd57f9e0654cd89a8fb56"},
+    {file = "rich-10.15.1-py3-none-any.whl", hash = "sha256:a59fb2721c52c5061ac65f318c0afb709e098b1ab6ce5813ea38982654c4b6ee"},
+    {file = "rich-10.15.1.tar.gz", hash = "sha256:93d0ea3c35ecfd8703dbe52b76885e224ad8d68c7766c921c726b14b22a57b7d"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1436,8 +1480,8 @@ sortedcontainers = [
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 starlette = [
-    {file = "starlette-0.17.0-py3-none-any.whl", hash = "sha256:64ffd950183d474df2cf7a4018c8bbb31a481367691c70f5ace4b2d376235f72"},
-    {file = "starlette-0.17.0.tar.gz", hash = "sha256:31a889e7d7bf487f70d9d197ed7efadb47fa938c58626ed93e381480833c5b84"},
+    {file = "starlette-0.17.1-py3-none-any.whl", hash = "sha256:26a18cbda5e6b651c964c12c88b36d9898481cd428ed6e063f5f29c418f73050"},
+    {file = "starlette-0.17.1.tar.gz", hash = "sha256:57eab3cc975a28af62f6faec94d355a410634940f10b30d68d31cb5ec1b44ae8"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.30.5"
+version = "0.30.6"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"
@@ -22,6 +22,7 @@ classifiers=[
 [tool.poetry.dependencies]
 python = ">=3.7.0,<4"
 anyio = "~3"
+graphlib2 = "<1"
 importlib-metadata = {version = ">=3", python = "<3.8"}
 typing-extensions = {version = ">=3", python = "<3.9"}
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -1,70 +1,94 @@
 import typing
-from typing import Iterable, Optional
+from typing import Any, Iterable, List, Optional
 
 import pytest
 
-from di.api.executor import AsyncTaskInfo, SyncExecutor, SyncTaskInfo, TaskInfo
+from di.api.dependencies import DependantBase
+from di.api.executor import AsyncTask, State, SyncExecutor, SyncTask, Task
 from di.dependant import Dependant
 from di.executors import DefaultExecutor, SimpleAsyncExecutor, SimpleSyncExecutor
+
+
+class TestAsyncTask(AsyncTask):
+    def __init__(
+        self,
+        dependant: DependantBase[Any],
+    ):
+        ...
+
+    async def compute(self, state: State) -> Iterable[Optional[Task]]:
+        raise NotImplementedError
+
+
+class TestSyncTask(SyncTask):
+    def __init__(
+        self,
+        dependant: DependantBase[Any],
+    ):
+        ...
+
+    def compute(self, state: State) -> Iterable[Optional[Task]]:
+        raise NotImplementedError
 
 
 @pytest.mark.parametrize("exc_cls", [DefaultExecutor, SimpleSyncExecutor])
 def test_executing_async_dependencies_in_sync_executor(
     exc_cls: typing.Type[SyncExecutor],
 ):
-    async def task() -> Iterable[None]:
-        return [None]
 
+    state = State()
     exc = exc_cls()
     match = "Cannot execute async dependencies in execute_sync"
     with pytest.raises(TypeError, match=match):
-        exc.execute_sync([AsyncTaskInfo(Dependant(), task)])
+        exc.execute_sync([TestAsyncTask(Dependant())], state)
 
 
 def test_simple_sync_executor():
-    executed: set[int] = set()
+    executed: List[int] = []
 
-    def task_1() -> Iterable[Optional[TaskInfo]]:
-        executed.add(1)
-        return [
-            SyncTaskInfo(Dependant(), task_2),
-        ]
+    class Task1(TestSyncTask):
+        def compute(self, state: State) -> Iterable[Optional[Task]]:
+            executed.append(1)
+            return [Task2(Dependant())]
 
-    def task_2() -> Iterable[Optional[TaskInfo]]:
-        executed.add(2)
-        return [SyncTaskInfo(Dependant(), task_3), None]
+    class Task2(TestSyncTask):
+        def compute(self, state: State) -> Iterable[Optional[Task]]:
+            executed.append(2)
+            return [Task3(Dependant())]
 
-    def task_3() -> Iterable[Optional[TaskInfo]]:
-        executed.add(3)
-        return []
+    class Task3(TestSyncTask):
+        def compute(self, state: State) -> Iterable[Optional[Task]]:
+            executed.append(3)
+            return [None]
 
     exc = SimpleSyncExecutor()
 
-    exc.execute_sync([SyncTaskInfo(Dependant(), task_1)])
+    exc.execute_sync([Task1(Dependant())], State())
 
-    assert executed == {1, 2, 3}
+    assert executed == [1, 2, 3]
 
 
 @pytest.mark.anyio
 async def test_simple_async_executor():
-    executed: set[int] = set()
+    executed: List[int] = []
 
-    async def task_1() -> Iterable[Optional[TaskInfo]]:
-        executed.add(1)
-        return [
-            AsyncTaskInfo(Dependant(), task_2),
-        ]
+    class Task1(TestAsyncTask):
+        async def compute(self, state: State) -> Iterable[Optional[Task]]:
+            executed.append(1)
+            return [Task2(Dependant())]
 
-    async def task_2() -> Iterable[Optional[TaskInfo]]:
-        executed.add(2)
-        return [SyncTaskInfo(Dependant(), task_3), None]
+    class Task2(TestAsyncTask):
+        async def compute(self, state: State) -> Iterable[Optional[Task]]:
+            executed.append(2)
+            return [Task3(Dependant())]
 
-    def task_3() -> Iterable[Optional[TaskInfo]]:
-        executed.add(3)
-        return []
+    class Task3(TestAsyncTask):
+        async def compute(self, state: State) -> Iterable[Optional[Task]]:
+            executed.append(3)
+            return [None]
 
     exc = SimpleAsyncExecutor()
 
-    await exc.execute_async([AsyncTaskInfo(Dependant(), task_1)])
+    await exc.execute_async([Task1(Dependant())], State())
 
-    assert executed == {1, 2, 3}
+    assert executed == [1, 2, 3]


### PR DESCRIPTION
There are unfortunately a lot of changes tangled up in here that come from changing the dependency resolution backend from the custom existing one to basically the `graphlib` API. So before merging this, the following questions need to be answered:
1. Is `graphlib2` better than `graphlib` for this application? It is clear that it is asymptotically faster, but it may be slower for very small inputs ([benchmarks](https://github.com/adriangb/graphlib2/blob/main/bench.ipynb)). But `graphlib` has no easy way to be deep-copied. Maybe we should just tweak the current implementation?
2. If we do use `graphlib2`, is it worth using the node id API over the plain hashable API? Pros are it may be faster (need benchmarks to confirm). Cons are that it is not interoperable with the stdlib graphlib implementation.
3. This change gets rid of subgraph pruning in favor of simply executing no-ops. This is conceptually murkier since it leaves a lot of open questions like what happens in A -> B -> C if A and C are cached but B is not (previously none would get executed, which is the right thing IMO, now B would get executed), but these are mostly edge-cases that can be resolved easily by users. Pruning subgraphs on every execution is very expensive, even if it is done in Rust extension code. I guess we need to be okay w/ this tradeoff.