### PR TITLE
feat!: accept and only allow @contextlib context managers or context manager classes

### DIFF
--- a/di/container.py
+++ b/di/container.py
@@ -32,7 +32,7 @@ else:
 from graphlib2 import TopologicalSorter
 
 from di._utils.execution_planning import SolvedDependantCache, plan_execution
-from di._utils.inspect import get_type, is_async_gen_callable, is_coroutine_callable
+from di._utils.inspect import get_type, is_async_context_manager, is_coroutine_callable
 from di._utils.scope_validation import validate_scopes
 from di._utils.state import ContainerState
 from di._utils.task import AsyncTask, SyncTask
@@ -276,7 +276,7 @@ class _ContainerCommon:
             keyword_parameters = tuple((k, v) for k, v in keyword.items())
 
             assert dep.call is not None
-            if is_async_gen_callable(dep.call) or is_coroutine_callable(dep.call):
+            if is_async_context_manager(dep.call) or is_coroutine_callable(dep.call):
                 tasks[dep.cache_key] = task = AsyncTask(
                     scope=dep.scope,
                     call=dep.call,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.50.0"
+version = "0.51.0"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+import contextlib
 from dataclasses import dataclass, field
 from typing import AsyncGenerator, Dict, Generator
 
@@ -16,6 +17,7 @@ class MyException(Exception):
     ...
 
 
+@contextlib.contextmanager
 def dep1(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -23,6 +25,7 @@ def dep1(rec: Recorder) -> Generator[None, None, None]:
         rec.caught["dep1"] = True
 
 
+@contextlib.contextmanager
 def dep2(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -30,6 +33,7 @@ def dep2(rec: Recorder) -> Generator[None, None, None]:
         rec.caught["dep2"] = True
 
 
+@contextlib.asynccontextmanager
 async def async_dep1(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -37,6 +41,7 @@ async def async_dep1(rec: Recorder) -> AsyncGenerator[None, None]:
         rec.caught["async_dep1"] = True
 
 
+@contextlib.asynccontextmanager
 async def async_dep2(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -134,6 +139,7 @@ async def test_dependency_can_catch_exception_concurrent_mixed() -> None:
     assert rec.caught == {"async_dep1": True} or rec.caught == {"dep2": True}
 
 
+@contextlib.contextmanager
 def dep1_reraise(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -142,6 +148,7 @@ def dep1_reraise(rec: Recorder) -> Generator[None, None, None]:
         raise
 
 
+@contextlib.contextmanager
 def dep2_reraise(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -150,6 +157,7 @@ def dep2_reraise(rec: Recorder) -> Generator[None, None, None]:
         raise
 
 
+@contextlib.asynccontextmanager
 async def async_dep1_reraise(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -158,6 +166,7 @@ async def async_dep1_reraise(rec: Recorder) -> AsyncGenerator[None, None]:
         raise
 
 
+@contextlib.asynccontextmanager
 async def async_dep2_reraise(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -284,6 +293,7 @@ async def test_dependency_can_catch_exception_concurrent_mixed_reraise() -> None
 
 
 def test_deep_reraise() -> None:
+    @contextlib.contextmanager
     def leaf() -> Generator[None, None, None]:
         try:
             yield
@@ -292,6 +302,7 @@ def test_deep_reraise() -> None:
         else:
             raise AssertionError("Exception did not propagate")  # pragma: no cover
 
+    @contextlib.contextmanager
     def parent(child: Annotated[None, Dependant(leaf)]) -> Generator[None, None, None]:
         try:
             yield

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -1,3 +1,4 @@
+import contextlib
 import typing
 
 import anyio
@@ -140,11 +141,13 @@ def test_nested_lifecycle():
 
     state: typing.Dict[str, str] = dict.fromkeys(("A", "B", "C"), "uninitialized")
 
+    @contextlib.contextmanager
     def A() -> typing.Generator[None, None, None]:
         state["A"] = "initialized"
         yield
         state["A"] = "destroyed"
 
+    @contextlib.contextmanager
     def B(
         a: Annotated[None, Dependant(A, scope="lifespan")]
     ) -> typing.Generator[None, None, None]:
@@ -152,6 +155,7 @@ def test_nested_lifecycle():
         yield
         state["B"] = "destroyed"
 
+    @contextlib.contextmanager
     def C(
         b: Annotated[None, Dependant(B, scope="request")]
     ) -> typing.Generator[None, None, None]:


### PR DESCRIPTION
Suggested by @graingert via Gitter

This supposedly makes things safer / less buggy (I still don't understand how)

What this does for sure do is enable context-manager classes (like httpx.AsyncClient) to be used as dependencies directly, and their context manager will be used. That's a pretty nice feature. Although it would also be possible to do that without requiring `@contextlib.{async}contextmanager` all over the place.

The alternative to this is to first call the thing, then check if it is a context manager.