### PR TITLE
perf/feat: enable @contextmanger without overhead

### DIFF
--- a/benchmarks/solve.py
+++ b/benchmarks/solve.py
@@ -2,6 +2,8 @@
 
 It will print out results to the console and open web browser windows.
 """
+import timeit
+
 import anyio
 from pyinstrument.profiler import Profiler  # type: ignore[import]
 
@@ -16,16 +18,19 @@ async def async_bench(sleep: SleepTimes, graph: GraphSize, iters: int) -> None:
     container = Container(scopes=[None])
     solved = container.solve(Dependant(generate_dag(graph, sync=False, sleep=sleep)))
     executor = ConcurrentAsyncExecutor()
-    p = Profiler()
+    # p = Profiler()
     async with container.enter_scope(None):
         await container.execute_async(solved, executor=executor)
-    p.start()
+    # p.start()
+    start = timeit.default_timer()
     for _ in range(iters):
         async with container.enter_scope(None):
             await container.execute_async(solved, executor=executor)
-    p.stop()
-    p.print()
-    p.open_in_browser()
+    end = timeit.default_timer()
+    # p.stop()
+    # p.print()
+    print(end - start)
+    # p.open_in_browser()
 
 
 def sync_bench(sleep: SleepTimes, graph: GraphSize, iters: int) -> None:
@@ -51,11 +56,11 @@ SLOW_DEPS = SleepTimes(1e-3, 1e-3)
 
 
 if __name__ == "__main__":
-    anyio.run(async_bench, FAST_DEPS, SMALL_GRAPH, 1_000)
+    # anyio.run(async_bench, FAST_DEPS, SMALL_GRAPH, 1_000)
     anyio.run(async_bench, FAST_DEPS, LARGE_GRAPH, 1_000)
-    anyio.run(async_bench, SLOW_DEPS, SMALL_GRAPH, 1_000)
-    anyio.run(async_bench, SLOW_DEPS, LARGE_GRAPH, 100)
-    sync_bench(FAST_DEPS, SMALL_GRAPH, iters=1_000)
-    sync_bench(FAST_DEPS, LARGE_GRAPH, iters=1_000)
-    sync_bench(SLOW_DEPS, SMALL_GRAPH, iters=1_000)
-    sync_bench(SLOW_DEPS, LARGE_GRAPH, iters=10)
+    # anyio.run(async_bench, SLOW_DEPS, SMALL_GRAPH, 1_000)
+    # anyio.run(async_bench, SLOW_DEPS, LARGE_GRAPH, 100)
+    # sync_bench(FAST_DEPS, SMALL_GRAPH, iters=1_000)
+    # sync_bench(FAST_DEPS, LARGE_GRAPH, iters=1_000)
+    # sync_bench(SLOW_DEPS, SMALL_GRAPH, iters=1_000)
+    # sync_bench(SLOW_DEPS, LARGE_GRAPH, iters=10)

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -77,7 +77,7 @@ def generate_dag(
     name = "final"
     deps = list(funcs.keys())
     params = ", ".join(
-        [f"dep_{dep_name}: Annotated[None, Dependant({dep_name})" for dep_name in deps]
+        [f"dep_{dep_name}: Annotated[None, Dependant({dep_name})]" for dep_name in deps]
     )
     func_def = template.format(name, params, 0)
     exec(func_def, globals, funcs)

--- a/di/_utils/execution_planning.py
+++ b/di/_utils/execution_planning.py
@@ -16,16 +16,13 @@ from typing import (
 from graphlib2 import TopologicalSorter
 
 from di._utils.scope_map import ScopeMap
-from di._utils.task import AsyncTask, ExecutionState, SyncTask, gather_new_tasks
-from di.api.executor import State as ExecutorState
+from di._utils.task import ExecutionState, Task, gather_new_tasks
 from di.api.executor import Task as ExecutorTask
 from di.api.providers import DependencyProvider
 from di.api.scopes import Scope
 from di.api.solved import SolvedDependant
 
 Dependency = Any
-
-Task = Union[AsyncTask, SyncTask]
 
 TaskCacheDeque = Deque[Tuple[Task, Scope]]
 
@@ -39,7 +36,6 @@ class SolvedDependantCache(NamedTuple):
 
     root_task: Task
     topological_sorter: TopologicalSorter[Task]
-    callable_to_task_mapping: Mapping[DependencyProvider, Iterable[Task]]
 
 
 def plan_execution(
@@ -48,36 +44,20 @@ def plan_execution(
     solved: SolvedDependant[Any],
     *,
     values: Optional[Mapping[DependencyProvider, Any]] = None,
-) -> Tuple[Dict[int, Any], Iterable[Optional[ExecutorTask]], ExecutorState, Task,]:
-    """Re-use or create an ExecutionPlan"""
-    # This function is a hot loop
-    # It is run for every execution, and even with the cache it can be a bottleneck
-    # This would be the best place to Cythonize or otherwise take more drastic measures
-
-    user_values = values or {}
-
-    solved_dependency_cache: SolvedDependantCache = solved.container_cache
-
-    # populate resulsts with values
-    results: "Results" = {}
-    call_map = solved_dependency_cache.callable_to_task_mapping
-    for call in user_values.keys() & call_map.keys():
-        value = user_values[call]
-        for task in call_map[call]:
-            results[task.task_id] = value
-
+) -> Tuple[Dict[int, Any], Iterable[Optional[ExecutorTask]], Any, Task,]:
+    solved_dependency_cache: "SolvedDependantCache" = solved.container_cache
     ts = solved_dependency_cache.topological_sorter.copy()
-
+    results: "Results" = {}
     execution_state = ExecutionState(
+        values=values or {},
         stacks=stacks,
         results=results,
         toplogical_sorter=ts,
         cache=cache,
     )
-
     return (
         results,
         gather_new_tasks(execution_state),
-        ExecutorState(execution_state),
+        execution_state,
         solved_dependency_cache.root_task,
     )

--- a/di/api/executor.py
+++ b/di/api/executor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, Iterable, NewType, Optional, Union
+from typing import Any, Awaitable, Iterable, Optional, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
@@ -10,35 +10,22 @@ else:
 
 from di.api.dependencies import DependantBase
 
-State = NewType("State", object)
 
-
-class AsyncTask:
+class Task:
     __slots__ = ()
     dependant: DependantBase[Any]
 
-    async def compute(self, state: State) -> Iterable[Union[None, Task]]:
+    def compute(
+        self, state: Any
+    ) -> Union[Iterable[Union[None, Task]], Awaitable[Iterable[Union[None, Task]]]]:
         ...
-
-
-class SyncTask:
-    __slots__ = ()
-    dependant: DependantBase[Any]
-
-    def compute(self, state: State) -> Iterable[Union[None, Task]]:
-        ...
-
-
-Task = Union[AsyncTask, SyncTask]
 
 
 class SyncExecutorProtocol(Protocol):
-    def execute_sync(self, tasks: Iterable[Optional[Task]], state: State) -> None:
+    def execute_sync(self, tasks: Iterable[Optional[Task]], state: Any) -> None:
         raise NotImplementedError
 
 
 class AsyncExecutorProtocol(Protocol):
-    async def execute_async(
-        self, tasks: Iterable[Optional[Task]], state: State
-    ) -> None:
+    async def execute_async(self, tasks: Iterable[Optional[Task]], state: Any) -> None:
         raise NotImplementedError

--- a/di/api/executor.py
+++ b/di/api/executor.py
@@ -11,8 +11,7 @@ else:
 from di.api.dependencies import DependantBase
 
 
-class Task:
-    __slots__ = ()
+class Task(Protocol):
     dependant: DependantBase[Any]
 
     def compute(

--- a/di/container.py
+++ b/di/container.py
@@ -32,7 +32,7 @@ else:
 from graphlib2 import TopologicalSorter
 
 from di._utils.execution_planning import SolvedDependantCache, plan_execution
-from di._utils.inspect import get_type, is_async_gen_callable, is_coroutine_callable
+from di._utils.inspect import get_type, is_async_context_manager, is_coroutine_callable
 from di._utils.scope_validation import validate_scopes
 from di._utils.state import ContainerState
 from di._utils.task import AsyncTask, SyncTask
@@ -276,7 +276,7 @@ class _ContainerCommon:
             keyword_parameters = tuple((k, v) for k, v in keyword.items())
 
             assert dep.call is not None
-            if is_async_gen_callable(dep.call) or is_coroutine_callable(dep.call):
+            if is_async_context_manager(dep.call) or is_coroutine_callable(dep.call):
                 tasks[dep.cache_key] = task = AsyncTask(
                     scope=dep.scope,
                     call=dep.call,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.50.0"
+version = "0.51.0"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+import contextlib
 from dataclasses import dataclass, field
 from typing import AsyncGenerator, Dict, Generator
 
@@ -16,6 +17,7 @@ class MyException(Exception):
     ...
 
 
+@contextlib.contextmanager
 def dep1(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -23,6 +25,7 @@ def dep1(rec: Recorder) -> Generator[None, None, None]:
         rec.caught["dep1"] = True
 
 
+@contextlib.contextmanager
 def dep2(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -30,6 +33,7 @@ def dep2(rec: Recorder) -> Generator[None, None, None]:
         rec.caught["dep2"] = True
 
 
+@contextlib.asynccontextmanager
 async def async_dep1(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -37,6 +41,7 @@ async def async_dep1(rec: Recorder) -> AsyncGenerator[None, None]:
         rec.caught["async_dep1"] = True
 
 
+@contextlib.asynccontextmanager
 async def async_dep2(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -134,6 +139,7 @@ async def test_dependency_can_catch_exception_concurrent_mixed() -> None:
     assert rec.caught == {"async_dep1": True} or rec.caught == {"dep2": True}
 
 
+@contextlib.contextmanager
 def dep1_reraise(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -142,6 +148,7 @@ def dep1_reraise(rec: Recorder) -> Generator[None, None, None]:
         raise
 
 
+@contextlib.contextmanager
 def dep2_reraise(rec: Recorder) -> Generator[None, None, None]:
     try:
         yield
@@ -150,6 +157,7 @@ def dep2_reraise(rec: Recorder) -> Generator[None, None, None]:
         raise
 
 
+@contextlib.asynccontextmanager
 async def async_dep1_reraise(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -158,6 +166,7 @@ async def async_dep1_reraise(rec: Recorder) -> AsyncGenerator[None, None]:
         raise
 
 
+@contextlib.asynccontextmanager
 async def async_dep2_reraise(rec: Recorder) -> AsyncGenerator[None, None]:
     try:
         yield
@@ -284,6 +293,7 @@ async def test_dependency_can_catch_exception_concurrent_mixed_reraise() -> None
 
 
 def test_deep_reraise() -> None:
+    @contextlib.contextmanager
     def leaf() -> Generator[None, None, None]:
         try:
             yield
@@ -292,6 +302,7 @@ def test_deep_reraise() -> None:
         else:
             raise AssertionError("Exception did not propagate")  # pragma: no cover
 
+    @contextlib.contextmanager
     def parent(child: Annotated[None, Dependant(leaf)]) -> Generator[None, None, None]:
         try:
             yield

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -256,16 +256,16 @@ class AsyncGenClsSlow:
 
 
 @pytest.mark.parametrize(
-    "dep1",
+    "dep1,sync1",
     [
-        sync_callable_func_slow,
-        async_callable_func_slow,
-        sync_gen_func_slow,
-        async_gen_func_slow,
-        SyncCallableClsSlow(),
-        AsyncCallableClsSlow(),
-        SyncGenClsSlow,
-        AsyncGenClsSlow,
+        (sync_callable_func_slow, True),
+        (async_callable_func_slow, False),
+        (sync_gen_func_slow, True),
+        (async_gen_func_slow, False),
+        (SyncCallableClsSlow(), True),
+        (AsyncCallableClsSlow(), False),
+        (SyncGenClsSlow, True),
+        (AsyncGenClsSlow, False),
     ],
     ids=[
         "sync_callable_func",
@@ -279,16 +279,16 @@ class AsyncGenClsSlow:
     ],
 )
 @pytest.mark.parametrize(
-    "dep2",
+    "dep2,sync2",
     [
-        sync_callable_func_slow,
-        async_callable_func_slow,
-        sync_gen_func_slow,
-        async_gen_func_slow,
-        SyncCallableClsSlow(),
-        AsyncCallableClsSlow(),
-        SyncGenClsSlow,
-        AsyncGenClsSlow,
+        (sync_callable_func_slow, True),
+        (async_callable_func_slow, False),
+        (sync_gen_func_slow, True),
+        (async_gen_func_slow, False),
+        (SyncCallableClsSlow(), True),
+        (AsyncCallableClsSlow(), False),
+        (SyncGenClsSlow, True),
+        (AsyncGenClsSlow, False),
     ],
     ids=[
         "sync_callable_func",
@@ -302,15 +302,15 @@ class AsyncGenClsSlow:
     ],
 )
 @pytest.mark.anyio
-async def test_concurrency_async(dep1: Any, dep2: Any):
+async def test_concurrency_async(dep1: Any, sync1: bool, dep2: Any, sync2: bool):
     container = Container(scopes=(None,))
 
     counter = Counter()
     container.register_by_type(Dependant(lambda: counter), Counter)
 
     async def collector(
-        a: Annotated[None, Dependant(dep1, use_cache=False, sync_to_thread=True)],
-        b: Annotated[None, Dependant(dep2, use_cache=False, sync_to_thread=True)],
+        a: Annotated[None, Dependant(dep1, use_cache=False, sync_to_thread=sync1)],
+        b: Annotated[None, Dependant(dep2, use_cache=False, sync_to_thread=sync2)],
     ):
         ...
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -13,7 +13,7 @@ class TestAsyncTask(Task):
         self,
         dependant: DependantBase[Any],
     ):
-        ...
+        self.dependant = dependant
 
     async def compute(self, state: Any) -> Iterable[Optional[Task]]:
         raise NotImplementedError
@@ -24,7 +24,7 @@ class TestSyncTask(Task):
         self,
         dependant: DependantBase[Any],
     ):
-        ...
+        self.dependant = dependant
 
     def compute(self, state: Any) -> Iterable[Optional[Task]]:
         raise NotImplementedError

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -3,36 +3,36 @@ from typing import Any, Iterable, List, Optional
 import pytest
 
 from di.api.dependencies import DependantBase
-from di.api.executor import AsyncTask, State, SyncTask, Task
+from di.api.executor import Task
 from di.dependant import Dependant
 from di.executors import AsyncExecutor, SyncExecutor
 
 
-class TestAsyncTask(AsyncTask):
+class TestAsyncTask(Task):
     def __init__(
         self,
         dependant: DependantBase[Any],
     ):
         ...
 
-    async def compute(self, state: State) -> Iterable[Optional[Task]]:
+    async def compute(self, state: Any) -> Iterable[Optional[Task]]:
         raise NotImplementedError
 
 
-class TestSyncTask(SyncTask):
+class TestSyncTask(Task):
     def __init__(
         self,
         dependant: DependantBase[Any],
     ):
         ...
 
-    def compute(self, state: State) -> Iterable[Optional[Task]]:
+    def compute(self, state: Any) -> Iterable[Optional[Task]]:
         raise NotImplementedError
 
 
 def test_executing_async_dependencies_in_sync_executor():
 
-    state = State(object())
+    state = object()
     exc = SyncExecutor()
     match = "Cannot execute async dependencies in execute_sync"
     with pytest.raises(TypeError, match=match):
@@ -43,23 +43,23 @@ def test_simple_sync_executor():
     executed: List[int] = []
 
     class Task1(TestSyncTask):
-        def compute(self, state: State) -> Iterable[Optional[Task]]:
+        def compute(self, state: Any) -> Iterable[Optional[Task]]:
             executed.append(1)
             return [Task2(Dependant())]
 
     class Task2(TestSyncTask):
-        def compute(self, state: State) -> Iterable[Optional[Task]]:
+        def compute(self, state: Any) -> Iterable[Optional[Task]]:
             executed.append(2)
             return [Task3(Dependant())]
 
     class Task3(TestSyncTask):
-        def compute(self, state: State) -> Iterable[Optional[Task]]:
+        def compute(self, state: Any) -> Iterable[Optional[Task]]:
             executed.append(3)
             return [None]
 
     exc = SyncExecutor()
 
-    exc.execute_sync([Task1(Dependant())], State(object()))
+    exc.execute_sync([Task1(Dependant())], object())
 
     assert executed == [1, 2, 3]
 
@@ -69,22 +69,22 @@ async def test_simple_async_executor():
     executed: List[int] = []
 
     class Task1(TestAsyncTask):
-        async def compute(self, state: State) -> Iterable[Optional[Task]]:
+        async def compute(self, state: Any) -> Iterable[Optional[Task]]:
             executed.append(1)
             return [Task2(Dependant())]
 
     class Task2(TestAsyncTask):
-        async def compute(self, state: State) -> Iterable[Optional[Task]]:
+        async def compute(self, state: Any) -> Iterable[Optional[Task]]:
             executed.append(2)
             return [Task3(Dependant())]
 
     class Task3(TestAsyncTask):
-        async def compute(self, state: State) -> Iterable[Optional[Task]]:
+        async def compute(self, state: Any) -> Iterable[Optional[Task]]:
             executed.append(3)
             return [None]
 
     exc = AsyncExecutor()
 
-    await exc.execute_async([Task1(Dependant())], State(object()))
+    await exc.execute_async([Task1(Dependant())], object())
 
     assert executed == [1, 2, 3]

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -1,3 +1,4 @@
+import contextlib
 import typing
 
 import anyio
@@ -140,11 +141,13 @@ def test_nested_lifecycle():
 
     state: typing.Dict[str, str] = dict.fromkeys(("A", "B", "C"), "uninitialized")
 
+    @contextlib.contextmanager
     def A() -> typing.Generator[None, None, None]:
         state["A"] = "initialized"
         yield
         state["A"] = "destroyed"
 
+    @contextlib.contextmanager
     def B(
         a: Annotated[None, Dependant(A, scope="lifespan")]
     ) -> typing.Generator[None, None, None]:
@@ -152,6 +155,7 @@ def test_nested_lifecycle():
         yield
         state["B"] = "destroyed"
 
+    @contextlib.contextmanager
     def C(
         b: Annotated[None, Dependant(B, scope="request")]
     ) -> typing.Generator[None, None, None]:


### PR DESCRIPTION
This is an alternative to #53 that achieves the same thing but instead of introspecting before running the dependency, it introspects after running it. To avoid the overhead of always introspecting, once we know what sort of dependency each task is tied to, we replace the introspecting execution path with a specialized one that does no introspection.

Overall this seems to perform _even better_ than the current fastest implementation (main).