### PR TITLE
feat: allow Dependant.cache_key to allow cache hits from outer scopes

### DIFF
--- a/di/_utils/execution_planning.py
+++ b/di/_utils/execution_planning.py
@@ -7,6 +7,7 @@ from graphlib2 import TopologicalSorter
 
 from di._utils.scope_map import ScopeMap
 from di._utils.task import ExecutionState, Task, gather_new_tasks
+from di._utils.types import CacheKey
 from di.api.executor import Task as ExecutorTask
 from di.api.providers import DependencyProvider
 from di.api.scopes import Scope
@@ -24,7 +25,7 @@ class SolvedDependantCache(NamedTuple):
 
 def plan_execution(
     stacks: Mapping[Scope, Union[AsyncExitStack, ExitStack]],
-    cache: ScopeMap[DependencyProvider, Any],
+    cache: ScopeMap[CacheKey, Any],
     solved: SolvedDependant[Any],
     *,
     values: Optional[Mapping[DependencyProvider, Any]] = None,

--- a/di/_utils/state.py
+++ b/di/_utils/state.py
@@ -5,8 +5,7 @@ from types import TracebackType
 from typing import Any, Dict, Optional, Type, Union
 
 from di._utils.scope_map import ScopeMap
-from di._utils.types import FusedContextManager
-from di.api.providers import DependencyProvider
+from di._utils.types import CacheKey, FusedContextManager
 from di.api.scopes import Scope
 
 
@@ -15,7 +14,7 @@ class ContainerState:
 
     def __init__(
         self,
-        cached_values: ScopeMap[DependencyProvider, Any],
+        cached_values: ScopeMap[CacheKey, Any],
         stacks: Dict[Scope, Union[AsyncExitStack, ExitStack]],
     ) -> None:
         self.cached_values = cached_values

--- a/di/_utils/types.py
+++ b/di/_utils/types.py
@@ -1,8 +1,23 @@
+import sys
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Any, Generic, Optional, Type, TypeVar, Union
 
+if sys.version_info < (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
+
+
 T = TypeVar("T")
+
+
+class CacheKey(Protocol):
+    def __hash__(self) -> int:
+        ...
+
+    def __eq__(self, __o: object) -> bool:
+        ...
 
 
 class FusedContextManager(Generic[T]):

--- a/di/api/dependencies.py
+++ b/di/api/dependencies.py
@@ -1,26 +1,16 @@
 from __future__ import annotations
 
 import inspect
-import sys
 from typing import Any, Generic, List, NamedTuple, Optional, TypeVar
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Protocol
-else:
-    from typing import Protocol
-
+from di._utils.types import CacheKey
 from di.api.providers import DependencyProviderType
 from di.api.scopes import Scope
 
 T = TypeVar("T")
 
 
-class CacheKey(Protocol):
-    def __hash__(self) -> int:
-        ...
-
-    def __eq__(self, __o: object) -> bool:
-        ...
+__all__ = ("CacheKey", "DependantBase", "DependencyParameter")
 
 
 class DependantBase(Generic[T]):

--- a/di/container.py
+++ b/di/container.py
@@ -216,16 +216,15 @@ class _ContainerCommon:
             cache_key = dep.cache_key
             if cache_key in dependants:
                 continue
-            else:
-                dependants[cache_key] = dep
-                params = get_params(dep)
-                param_graph[dep] = params
-                dep_dag[dep] = []
-                for param in params:
-                    predecessor_dep = param.dependency
-                    dep_dag[dep].append(predecessor_dep)
-                    if predecessor_dep not in dependants:
-                        q.append(predecessor_dep)
+            dependants[cache_key] = dep
+            params = get_params(dep)
+            param_graph[dep] = params
+            dep_dag[dep] = []
+            for param in params:
+                predecessor_dep = param.dependency
+                dep_dag[dep].append(predecessor_dep)
+                if predecessor_dep not in dependants:
+                    q.append(predecessor_dep)
         # Filter out any dependencies that do not have a call
         # These do not become tasks since they don't need to be computed
         computable_param_graph = {

--- a/di/container.py
+++ b/di/container.py
@@ -296,6 +296,7 @@ class _ContainerCommon:
                 scope=dep.scope,
                 call=dep.call,
                 use_cache=dep.use_cache,
+                cache_key=dep.cache_key,
                 dependant=dep,
                 task_id=task_id,
                 positional_parameters=positional_parameters,

--- a/di/dependant.py
+++ b/di/dependant.py
@@ -134,7 +134,7 @@ class Dependant(DependantBase[T]):
                     sub_dependant = maybe_sub_dependant
                 elif param.default is param.empty:
                     # try to auto-wire
-                    sub_dependant = Dependant[Any](
+                    sub_dependant = self.__class__(
                         call=None,
                         scope=self.scope,
                         use_cache=self.use_cache,
@@ -142,7 +142,7 @@ class Dependant(DependantBase[T]):
                 else:
                     # has a default parameter but we create a dependency anyway just for binds
                     # but do not wire it to make autowiring less brittle and less magic
-                    sub_dependant = Dependant[Any](
+                    sub_dependant = self.__class__(
                         call=None,
                         scope=self.scope,
                         use_cache=self.use_cache,

--- a/di/dependant.py
+++ b/di/dependant.py
@@ -132,24 +132,27 @@ class Dependant(DependantBase[T]):
                 maybe_sub_dependant = next(get_markers_from_parameter(param), None)
                 if maybe_sub_dependant is not None:
                     sub_dependant = maybe_sub_dependant
-                elif param.default is param.empty:
-                    # try to auto-wire
-                    sub_dependant = self.__class__(
-                        call=None,
-                        scope=self.scope,
-                        use_cache=self.use_cache,
-                    )
                 else:
-                    # has a default parameter but we create a dependency anyway just for binds
-                    # but do not wire it to make autowiring less brittle and less magic
-                    sub_dependant = self.__class__(
-                        call=None,
-                        scope=self.scope,
-                        use_cache=self.use_cache,
-                        wire=False,
-                    )
+                    sub_dependant = self.initialize_sub_dependant(param)
             res.append(DependencyParameter(dependency=sub_dependant, parameter=param))
         return res
+
+    def initialize_sub_dependant(self, param: inspect.Parameter) -> DependantBase[Any]:
+        if param.default is param.empty:
+            # try to auto-wire
+            return Dependant[Any](
+                call=None,
+                scope=self.scope,
+                use_cache=self.use_cache,
+            )
+        # has a default parameter but we create a dependency anyway just for binds
+        # but do not wire it to make autowiring less brittle and less magic
+        return Dependant[Any](
+            call=None,
+            scope=self.scope,
+            use_cache=self.use_cache,
+            wire=False,
+        )
 
     def __repr__(self) -> str:
         return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.53.4"
+version = "0.54.0"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"


### PR DESCRIPTION
This allows a "request" scoped dependency to use a value cached in the "app" scope