### PR TITLE
refactor: remove __slots__ from Dependant

### DIFF
--- a/di/api/dependencies.py
+++ b/di/api/dependencies.py
@@ -20,8 +20,6 @@ class DependantBase(Generic[T]):
     - A callable who's returned value is the dependency
     """
 
-    __slots__ = ("call", "scope", "use_cache")
-
     call: Optional[DependencyProviderType[T]]
     scope: Scope
     use_cache: bool

--- a/di/dependant.py
+++ b/di/dependant.py
@@ -24,8 +24,6 @@ T = TypeVar("T")
 
 
 class Dependant(DependantBase[T]):
-    __slots__ = ("wire", "sync_to_thread", "overrides")
-
     @overload
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.54.0"
+version = "0.54.1"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"


### PR DESCRIPTION
We no longer access any of Dependant's attributes are runtime (that's all done in Task), so we can remove this with no performance impact