### PR TITLE
BREAKING_CHANGE: dissallow using a dependency with different scopes

### DIFF
--- a/di/container.py
+++ b/di/container.py
@@ -42,7 +42,7 @@ from di.api.executor import AsyncExecutorProtocol, SyncExecutorProtocol
 from di.api.providers import DependencyProvider
 from di.api.scopes import Scope
 from di.api.solved import SolvedDependant
-from di.exceptions import WiringError
+from di.exceptions import SolvingError, WiringError
 
 __all__ = ("BaseContainer", "Container")
 
@@ -217,6 +217,12 @@ class _ContainerCommon:
             seen.add(dep)
             cache_key = dep.cache_key
             if cache_key in dependants:
+                other = dependants[cache_key]
+                if other.scope != dep.scope:
+                    raise SolvingError(
+                        f"The dependency {dep.call} is used with multiple scopes"
+                        f" ({dep.scope} and {other.scope}); this is not allowed."
+                    )
                 continue
             dependants[cache_key] = dep
             params = get_params(dep)

--- a/di/dependant.py
+++ b/di/dependant.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Iterable, List, Mapping, Optional, Type, TypeVar, overload
+from typing import Any, Iterable, List, Mapping, Optional, TypeVar, overload
 
 from di._utils.inspect import get_parameters, get_type
 from di.api.dependencies import CacheKey, DependantBase, DependencyParameter
@@ -9,12 +9,10 @@ from di.api.providers import (
     AsyncGeneratorProvider,
     CallableProvider,
     CoroutineProvider,
-    DependencyProvider,
     DependencyProviderType,
     GeneratorProvider,
 )
 from di.api.scopes import Scope
-from di.exceptions import ScopeViolationError
 from di.typing import get_markers_from_parameter
 
 _VARIABLE_PARAMETER_KINDS = (
@@ -99,7 +97,7 @@ class Dependant(DependantBase[T]):
     def cache_key(self) -> CacheKey:
         if self.use_cache is False or self.call is None:
             return (self.__class__, id(self))
-        return _DependantCacheKey(cls=self.__class__, call=self.call, scope=self.scope)
+        return (self.__class__, self.call)
 
     def register_parameter(self, param: inspect.Parameter) -> DependantBase[Any]:
         """Hook to register the parameter this Dependant corresponds to.
@@ -158,37 +156,6 @@ class Dependant(DependantBase[T]):
         return (
             f"{self.__class__.__name__}(call={self.call}, use_cache={self.use_cache})"
         )
-
-
-class _DependantCacheKey:
-    __slots__ = ("cls", "scope", "call", "hash")
-
-    def __init__(
-        self,
-        cls: Type[Dependant[Any]],
-        scope: Scope,
-        call: Optional[DependencyProvider],
-    ) -> None:
-        self.cls = cls
-        self.scope = scope
-        self.call = call
-        self.hash = hash((self.cls, self.call))
-
-    def __hash__(self) -> int:
-        return self.hash
-
-    def __eq__(self, __o: object) -> bool:
-        if __o is self:
-            return True
-        if not isinstance(__o, _DependantCacheKey):
-            return False
-        if __o.cls is not self.cls or __o.call is not self.call:
-            return False
-        if __o.scope != self.scope:
-            raise ScopeViolationError(
-                f"The dependency {self.call} is used with multiple scopes in the same dependency graph"
-            )
-        return True
 
 
 class JoinedDependant(DependantBase[T]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.54.2"
+version = "0.55.0"
 description = "Autowiring dependency injection"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_dependant.py
+++ b/tests/test_dependant.py
@@ -33,7 +33,6 @@ class DependantSubclass(Dependant[T]):
         ),
         (Dependant(func), DependantSubclass(func), False, False),
         (Dependant(func), Dependant(other_func), False, False),
-        (Dependant(func, scope=0), Dependant(func, scope=1), False, False),
         (Dependant(None), Dependant(None), False, False),
     ],
 )

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -186,3 +186,22 @@ def test_unknown_scope():
     container = Container()
     with pytest.raises(UnknownScopeError):
         container.solve(Dependant(bad_dep))
+
+
+def test_re_used_dependant() -> None:
+    def dep1() -> None:
+        ...
+
+    Dep1 = Annotated[None, Dependant(dep1)]
+
+    def dep2(one: Dep1) -> None:
+        ...
+
+    def dep3(
+        one: Dep1,
+        two: Annotated[None, Dependant(dep2)],
+    ) -> None:
+        ...
+
+    container = Container(scopes=(None,))
+    container.solve(Dependant(dep3, scope=None))

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -5,7 +5,12 @@ import pytest
 from di import Container, Dependant, SyncExecutor
 from di.api.dependencies import DependencyParameter
 from di.dependant import JoinedDependant
-from di.exceptions import ScopeViolationError, UnknownScopeError, WiringError
+from di.exceptions import (
+    ScopeViolationError,
+    SolvingError,
+    UnknownScopeError,
+    WiringError,
+)
 from di.typing import Annotated
 
 
@@ -77,7 +82,7 @@ def test_dependency_with_multiple_scopes():
         ...
 
     container = Container(scopes=("app", "request"))
-    with pytest.raises(ScopeViolationError, match="used with multiple scopes"):
+    with pytest.raises(SolvingError, match="used with multiple scopes"):
         container.solve(Dependant(B, scope="request"))
 
 

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -80,10 +80,8 @@ def test_dependency_with_multiple_scopes():
         assert a1 != a2
 
     container = Container(scopes=("app", "request"))
-    solved = container.solve(Dependant(B, scope="request"))
-    with container.enter_scope("app"):
-        with container.enter_scope("request"):
-            container.execute_sync(solved, executor=SyncExecutor())
+    with pytest.raises(ScopeViolationError, match="used with multiple scopes"):
+        container.solve(Dependant(B, scope="request"))
 
 
 def test_siblings() -> None:

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -67,17 +67,14 @@ def test_dissalow_depending_on_inner_scope():
 
 
 def test_dependency_with_multiple_scopes():
-
-    values = iter(range(2))
-
-    def A() -> int:
-        return next(values)
+    def A() -> None:
+        ...
 
     def B(
         a1: Annotated[None, Dependant(A, scope="app")],
         a2: Annotated[None, Dependant(A, scope="request")],
     ) -> None:
-        assert a1 != a2
+        ...
 
     container = Container(scopes=("app", "request"))
     with pytest.raises(ScopeViolationError, match="used with multiple scopes"):


### PR DESCRIPTION
Closes #58.

This change explicitly prohibits using the same dependency with multiple scopes _within a given DAG_, thus resolving #58.

It is important to note the _within a given DAG_ part: you can still use the same dependency in two completely separate DAGs with different scopes. In this case, caching between them _will_ work: if the dependency is cached in an outer scope, the cached value will be used, but if it is cached in an inner scope, it will be ignored (this behavior is [here](https://github.com/adriangb/di/blob/c988f5c317965b1111ec94cc08df3497219b7933/di/_utils/scope_map.py#L23-L27))