### PR TITLE
feat: check dependency marker return annotations against parameter

### DIFF
--- a/di/_utils/inspect.py
+++ b/di/_utils/inspect.py
@@ -83,10 +83,25 @@ def get_parameters(call: Callable[..., Any]) -> Dict[str, inspect.Parameter]:
     return processed_params
 
 
-def get_type(param: inspect.Parameter) -> Optional[Some]:
+def get_type_from_param(param: inspect.Parameter) -> Optional[Some]:
     annotation = param.annotation
     if annotation is param.empty:
         return None
     if get_origin(annotation) is Annotated:
         annotation = next(iter(get_args(annotation)))
+    if isinstance(None, annotation):
+        return Some(None)
     return Some(annotation)
+
+
+def get_return_type_from_call(call: Any) -> Optional[Some]:
+    if not callable(call):
+        raise TypeError
+    return_annotation = inspect.signature(call).return_annotation
+    if return_annotation is inspect.Signature.empty:
+        return None
+    if is_gen_callable(call) or is_async_gen_callable(call):
+        return_annotation = next(iter(get_args(return_annotation)))
+    if isinstance(None, return_annotation):
+        return Some(None)
+    return Some(return_annotation)

--- a/di/_utils/inspect.py
+++ b/di/_utils/inspect.py
@@ -89,7 +89,7 @@ def get_type_from_param(param: inspect.Parameter) -> Optional[Some]:
         return None
     if get_origin(annotation) is Annotated:
         annotation = next(iter(get_args(annotation)))
-    if isinstance(None, annotation):
+    if annotation is type(None):  # noqa: E721
         return Some(None)
     return Some(annotation)
 
@@ -102,6 +102,6 @@ def get_return_type_from_call(call: Any) -> Optional[Some]:
         return None
     if is_gen_callable(call) or is_async_gen_callable(call):
         return_annotation = next(iter(get_args(return_annotation)))
-    if isinstance(None, return_annotation):
+    if return_annotation is type(None):  # noqa: E721
         return Some(None)
     return Some(return_annotation)

--- a/di/container/_bind_by_type_hook.py
+++ b/di/container/_bind_by_type_hook.py
@@ -1,7 +1,7 @@
 import inspect
 from typing import Any, Optional
 
-from di._utils.inspect import get_type
+from di._utils.inspect import get_type_from_param
 from di.api.dependencies import DependantBase
 from di.container._bind_hook import BindHook
 
@@ -19,7 +19,7 @@ def bind_by_type(
             return provider
         if param is None:
             return None
-        type_annotation_option = get_type(param)
+        type_annotation_option = get_type_from_param(param)
         if type_annotation_option is None:
             return None
         type_annotation = type_annotation_option.value

--- a/di/exceptions.py
+++ b/di/exceptions.py
@@ -50,3 +50,7 @@ class SolvingError(DependencyInjectionException):
 
 class IncompatibleDependencyError(DependencyInjectionException):
     """Raised when an async context manager dependency is executed in a sync Scope"""
+
+
+class DependencyReturnAssignmentError(DependencyInjectionException):
+    """Raised in situations like `param: Annotated[int, Marker(function_returns_str)`"""

--- a/tests/test_dependency_cycles.py
+++ b/tests/test_dependency_cycles.py
@@ -9,12 +9,12 @@ from di.typing import Annotated
 
 # These methods need to be defined at the global scope for
 # forward references to be resolved correctly at runtime
-def dep1(v: "Annotated[int, Marker(dep2)]") -> None:  # type: ignore
-    ...  # pragma: no cover
+def dep1(v: "Annotated[int, Marker(dep2)]") -> int:  # type: ignore
+    return 1  # pragma: no cover
 
 
-def dep2(v: "Annotated[int, Marker(dep1)]") -> None:
-    ...  # pragma: no cover
+def dep2(v: "Annotated[int, Marker(dep1)]") -> int:
+    return 2  # pragma: no cover
 
 
 def test_cycle() -> None:

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -37,6 +37,20 @@ def test_wiring_missing_return_value() -> None:
     container.solve(dep, scopes=[None])
 
 
+def test_wiring_returns_subtype() -> None:
+    def f() -> float:
+        return 1
+
+    def g(v: Annotated[int, Marker(f)]) -> None:
+        pass
+
+    container = Container()
+    dep = Dependant(g)
+
+    # no error raised because int is a subtype of float
+    container.solve(dep, scopes=[None])
+
+
 def test_wiring_based_from_annotation() -> None:
     def g() -> int:
         return 1

--- a/tests/test_wiring_annotated.py
+++ b/tests/test_wiring_annotated.py
@@ -1,34 +1,8 @@
-from typing import Optional, Tuple
+from typing import Tuple
 
 from di.container import Container, bind_by_type
-from di.dependant import Dependant, Marker
+from di.dependant import Dependant
 from di.executors import SyncExecutor
-from di.typing import Annotated
-
-
-def test_wiring_based_from_annotation() -> None:
-    def g() -> int:
-        return 1
-
-    class G:
-        pass
-
-    dep_a = Marker(g)
-    dep_b = "foo bar baz!"
-    dep_c = Marker(g, use_cache=False)
-    dep_d = Marker(g)
-
-    def f(
-        a: Annotated[int, dep_a],
-        b: Annotated[G, dep_b],
-        c: Annotated[int, dep_c],
-        d: Annotated[Optional[int], dep_d] = None,
-    ) -> None:
-        pass
-
-    dep = Dependant(f)
-    subdeps = dep.get_dependencies()
-    assert [d.dependency.call for d in subdeps] == [g, G, g, g]
 
 
 def test_autowiring_class_with_default_builtin() -> None:


### PR DESCRIPTION
While we can't type check dependencies in `Annotated` (at some point a MyPy plugin to do this would be nice) we can, maybe, type check them at runtime. Since most things using `di` will have a sort of "compile" phase where they are doing dependency resolution (hopefully they do), this should provide _some_ type safety.

My main concerns are:

1. Is this a good thing to have long term?
2. Opening up the door for a lot of edge cases