### PR TITLE
docs: fix examples lines

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -10,7 +10,7 @@ Dependencies are cached by their cache key, computed in `Dependant.cache_key`.
 See [dependants] for more information on `Dependant.cache_key`.
 Dependencies are cached by default, but this behavior can be changed on a per-dependency basis using the `use_cache=False` parameter to `Dependant`.
 
-```Python hl_lines="8-13"
+```Python hl_lines="10-15"
 --8<-- "docs_src/sharing.py"
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,7 +20,7 @@ In this example, we'll look at what it would take for a web framework to provide
 
 Let's start by looking at the User's code.
 
-```python hl_lines="20-30"
+```python hl_lines="22-32"
 --8<-- "docs_src/web_framework.py"
 ```
 
@@ -33,13 +33,13 @@ This part can get a bit complex, but it's okay because it's written once, in a l
 First, we'll need to create a `Container` instance.
 This would be tied to the `App` or `Router` instance of the web framework.
 
-```python hl_lines="11"
+```python hl_lines="13"
 --8<-- "docs_src/web_framework.py"
 ```
 
 Next, we "solve" the users' endpoint:
 
-```python hl_lines="12"
+```python hl_lines="14"
 --8<-- "docs_src/web_framework.py"
 ```
 
@@ -49,7 +49,7 @@ This is very important for performance: we want to do the least amount of work p
 
 Finally, we execute the endpoint for each incoming request:
 
-```python hl_lines="13-16"
+```python hl_lines="15-18"
 --8<-- "docs_src/web_framework.py"
 ```
 

--- a/docs/solving.md
+++ b/docs/solving.md
@@ -24,7 +24,7 @@ For example, here is a more advanced use case where the framework solves the end
 
 This means that `di` does *not* do any reflection for each request, nor does it have to do dependency resolution.
 
-```Python hl_lines="11-13 16-18"
+```Python hl_lines="13-15 18-20"
 --8<-- "docs_src/solved_dependant.py"
 ```
 
@@ -32,7 +32,7 @@ This means that `di` does *not* do any reflection for each request, nor does it 
 
 You can easily list all dependencies in a dag via `SolvedDependant.dag.keys()`.
 
-```Python hl_lines="20"
+```Python hl_lines="22"
 --8<-- "docs_src/solved_dependant.py"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.70.0"
+version = "0.70.1"
 description = "Dependency injection toolkit"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"


### PR DESCRIPTION
Hello! Thanks for this fantastic project. I just started using it and while digesting the docs I found these little errors.

Besides this small fix, I'd like to ask if it would be possible to add some docstrings to some functions and classes.
I tend to hover over the objects in my editor to read the description, and now I find myself searching in the docs to find mostly examples, not what the particular functions does. Some examples are: `bind_by_type`, `Container`, `enter_scope`, `ConcurrentAsyncExecutor`. I'm new to DI so I'm still building my intuition and it would be really helpful 🙏🏻 .

Thanks again! 