### PR TITLE
refactor: remove the unused `_state` slot from the `Container`

### DIFF
--- a/di/_container.py
+++ b/di/_container.py
@@ -606,7 +606,7 @@ class Container:
     Solving is very expensive so avoid doing it in a hot loop.
     """
 
-    __slots__ = ("_bind_hooks", "_state")
+    __slots__ = ("_bind_hooks",)
 
     _bind_hooks: List[BindHook]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "di"
-version = "0.75.1"
+version = "0.75.2"
 description = "Dependency injection toolkit"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"


### PR DESCRIPTION
The `__slots__` of the `Container` class [has](https://github.com/adriangb/di/blob/104f006e4bce22564af566f3bba7f06c4314b40f/di/_container.py#L609) a declared `_state` attribute that is never used internally. Is there a reason for declaring it, maybe it should be removed?
I found [a commit](https://github.com/adriangb/di/commit/c2c1036ccfb4c3b82ffefeebd761861647f33de1#diff-81643a36ae17d4c8f65597e4fc0bc70ce7c1a412f98f9d1c1ac450107821fba7) with the first addition of this attribute, but I still don't see a reason for it.
If there is, maybe it should be documented with a comment?
